### PR TITLE
Here's a better patch for waiting on child processes

### DIFF
--- a/lib/foreman/engine.rb
+++ b/lib/foreman/engine.rb
@@ -39,8 +39,8 @@ class Foreman::Engine
       fork process, options
     end
 
-    trap("TERM") { kill_and_exit("TERM") }
-    trap("INT")  { kill_and_exit("INT")  }
+    trap("TERM") { kill_all("TERM") }
+    trap("INT")  { kill_all("INT")  }
 
     watch_for_termination
   end
@@ -48,8 +48,8 @@ class Foreman::Engine
   def execute(name, options={})
     fork processes[name], options
 
-    trap("TERM") { kill_and_exit("TERM") }
-    trap("INT")  { kill_and_exit("INT")  }
+    trap("TERM") { kill_all("TERM") }
+    trap("INT")  { kill_all("INT")  }
 
     watch_for_termination
   end
@@ -97,18 +97,15 @@ private ######################################################################
       rescue PTY::ChildExited, Interrupt
         info "process exiting", process
       end
-      Process.waitall
     end
   end
 
-  def kill_and_exit(signal="TERM")
+  def kill_all(signal="TERM")
     info "terminating"
     running_processes.each do |pid, process|
       info "killing #{process.name} in pid #{pid}"
       Process.kill(signal, pid)
     end
-    Process.waitall
-    exit 0
   end
 
   def info(message, process=nil)
@@ -151,7 +148,8 @@ private ######################################################################
     pid, status = Process.wait2
     process = running_processes.delete(pid)
     info "process terminated", process
-    kill_and_exit
+    kill_all
+    Process.waitall
   end
 
   def running_processes


### PR DESCRIPTION
I noticed you pulled in my patch for Process.waitall recently. Thanks! Unfortunately, it wasn't really tested and I didn't mean to ask you to merge it in. Sorry about that. It actually causes foreman to keep running even after the first Control-C. You have to press Control-C again to get it to finish.

Here's a better patch, more like what I wanted to do before. It sometimes winds up killing some processes twice, but at least it behaves nicely (and doesn't let children keep running after the parent exits).
