### PR TITLE
Upstart process su'ing into wrong dir

### DIFF
--- a/data/export/upstart/process.conf.erb
+++ b/data/export/upstart/process.conf.erb
@@ -2,4 +2,5 @@ start on starting <%= app %>-<%= process.name %>
 stop on stopping <%= app %>-<%= process.name %>
 respawn
 
-exec su - <%= user %> -c 'chdir <%= engine.directory %>; export PORT=<%= port %>; <%= process.command %> >> <%= log_root %>/<%=process.name%>-<%=num%>.log 2>&1'
+chdir <%= engine.directory %>
+exec su <%= user %> -c 'export PORT=<%= port %>; <%= process.command %> >> <%= log_root %>/<%=process.name%>-<%=num%>.log 2>&1'


### PR DESCRIPTION
Moved upstart process 'chdir' into after su into user, since that will change dir to user home.

I'm working on Rails app that is deployed via Capistrano, to a directory that is the ssh user's home. Basically, the user is deploy, the app root is in /home/app/current. I exported to upstart using this command:

```
bundle exec foreman export upstart /etc/init -a app -u deploy
```

However, whenever I ran my process file, I got errors that it couldn't find the script I was trying to run. I determined this to be because after the process su'ed into the other user, the shell was in that users home directory, not the app. This patch seems to fix that.

Best,
Clif
