### PR TITLE
Added command to set RAILS_ENV

### DIFF
--- a/data/export/upstart/process.conf.erb
+++ b/data/export/upstart/process.conf.erb
@@ -3,4 +3,4 @@ stop on stopping <%= app %>-<%= process.name %>
 respawn
 
 chdir <%= engine.directory %>
-exec su <%= user %> -c 'export PORT=<%= port %>; <%= process.command %> >> <%= log_root %>/<%=process.name%>-<%=num%>.log 2>&1'
+exec su <%= user %> -c 'export PORT=<%= port %>; export RAILS_ENV=<%= rails_env %>; <%= process.command %> >> <%= log_root %>/<%=process.name%>-<%=num%>.log 2>&1'

--- a/lib/foreman/cli.rb
+++ b/lib/foreman/cli.rb
@@ -30,6 +30,7 @@ class Foreman::CLI < Thor
   method_option :log,         :type => :string,  :aliases => "-l"
   method_option :port,        :type => :numeric, :aliases => "-p"
   method_option :user,        :type => :string,  :aliases => "-u"
+  method_option :rails_env,   :type => :string,  :aliases => "-e"
   method_option :concurrency, :type => :string,  :aliases => "-c",
     :banner => '"alpha=5,bar=3"'
 

--- a/lib/foreman/export/inittab.rb
+++ b/lib/foreman/export/inittab.rb
@@ -16,7 +16,7 @@ class Foreman::Export::Inittab < Foreman::Export::Base
       1.upto(concurrency[process.name]) do |num|
         id = app.slice(0, 2).upcase + sprintf("%02d", index)
         port = engine.port_for(process, num, options[:port])
-        inittab << "#{id}:4:respawn:/bin/su - #{user} -c 'PORT=#{port} #{process.command} >> #{log_root}/#{process.name}-#{num}.log 2>&1'"
+        inittab << "#{id}:4:respawn:/bin/su - #{user} -c 'PORT=#{port} RAILS_ENV=#{rails_env} #{process.command} >> #{log_root}/#{process.name}-#{num}.log 2>&1'"
         index += 1
       end
       index

--- a/lib/foreman/export/upstart.rb
+++ b/lib/foreman/export/upstart.rb
@@ -11,6 +11,7 @@ class Foreman::Export::Upstart < Foreman::Export::Base
     app = options[:app] || File.basename(engine.directory)
     user = options[:user] || app
     log_root = options[:log] || "/var/log/#{app}"
+    rails_env = options[:rails_env] || "production"
 
     Dir["#{location}/#{app}*.conf"].each do |file|
       say "cleaning up: #{file}"


### PR DESCRIPTION
Added a new command line option '-e', to set RAILS_ENV for upstart/inittab processes. Defaults to production, since that seems to be the scenario most people will be exporting.
