### PR TITLE
Change requires so export/upstart_spec can run on its own

### DIFF
--- a/lib/foreman/export.rb
+++ b/lib/foreman/export.rb
@@ -4,5 +4,6 @@ module Foreman::Export
   class Exception < ::Exception; end
 end
 
+require "foreman/export/base"
 require "foreman/export/inittab"
 require "foreman/export/upstart"

--- a/lib/foreman/export/inittab.rb
+++ b/lib/foreman/export/inittab.rb
@@ -1,4 +1,4 @@
-require "foreman/export/base"
+require "foreman/export"
 
 class Foreman::Export::Inittab < Foreman::Export::Base
 

--- a/lib/foreman/export/upstart.rb
+++ b/lib/foreman/export/upstart.rb
@@ -1,5 +1,5 @@
 require "erb"
-require "foreman/export/base"
+require "foreman/export"
 
 class Foreman::Export::Upstart < Foreman::Export::Base
 

--- a/spec/foreman/export/upstart_spec.rb
+++ b/spec/foreman/export/upstart_spec.rb
@@ -1,4 +1,5 @@
 require "spec_helper"
+require "foreman/engine"
 require "foreman/export/upstart"
 
 describe Foreman::Export::Upstart do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,7 +3,7 @@ require "rspec"
 require "fakefs/safe"
 require "fakefs/spec_helpers"
 
-$:.unshift "lib"
+$:.unshift File.expand_path("../../lib", __FILE__)
 
 def mock_error(subject, message)
   mock_exit do


### PR DESCRIPTION
Was checking things out, started by running `bundle exec rake`. Saw upstart_spec failed due to a path issue; the static example files have a hard-coded home directory in them that makes the specs fail.

In exploring how to fix that, I was trying to run upstart_spec by itself with `bundle exec rspec spec/foreman/export/upstart_spec.rb` but it was having trouble requiring what it needed. I shuffled things a little to make it happy. Also added a require for foreman/engine to upstart_spec.
