### PR TITLE
Fix grammar in man page

### DIFF
--- a/man/foreman.1.ronn
+++ b/man/foreman.1.ronn
@@ -38,7 +38,7 @@ The following options control how the application is run:
 `foreman export` is used to export your application to another process
 management format.
 
-An location to export can be passed as an argument. This argument may be
+A location to export can be passed as an argument. This argument may be
 either required or optional depending on the export format.
 
 The following options control how the application is run:


### PR DESCRIPTION
Replaces "an location" with "a location".
