### PR TITLE
Loading the shell environment in the exported upstart configuration

### DIFF
--- a/data/export/upstart/process.conf.erb
+++ b/data/export/upstart/process.conf.erb
@@ -2,5 +2,4 @@ start on starting <%= app %>-<%= process.name %>
 stop on stopping <%= app %>-<%= process.name %>
 respawn
 
-chdir <%= engine.directory %>
-exec su - <%= user %> -c 'export PORT=<%= port %>; <%= process.command %> >> <%= log_root %>/<%=process.name%>-<%=num%>.log 2>&1'
+exec su - <%= user %> -c 'cd <%= engine.directory %>; export PORT=<%= port %>; <%= process.command %> >> <%= log_root %>/<%=process.name%>-<%=num%>.log 2>&1'


### PR DESCRIPTION
Per this issue (https://github.com/ddollar/foreman/issues/24), I've changed the upstart export template to load the full shell environment with the - option when executing, as well as to change to the appropriate directory for execution.  Have used the new templates successfully for deployment on Ubuntu, and things seem to be looking good.
