### PR TITLE
Gracefully handle the 'garbage in' of an empty .foreman file.

### DIFF
--- a/lib/foreman/cli.rb
+++ b/lib/foreman/cli.rb
@@ -86,7 +86,7 @@ private ######################################################################
   def options
     original_options = super
     return original_options unless File.exists?(".foreman")
-    defaults = YAML::load_file(".foreman")
+    defaults = YAML::load_file(".foreman") || {}
     Thor::CoreExt::HashWithIndifferentAccess.new(defaults.merge(original_options))
   end
 


### PR DESCRIPTION
I ran `touch .foreman` to play around with some settings. But I forgot to edit it, causing some confusing errors when I ran `foreman check` a few minutes later. Doh!
