### PR TITLE
Adds erb pre-processing to procfiles

### DIFF
--- a/spec/foreman/engine_spec.rb
+++ b/spec/foreman/engine_spec.rb
@@ -13,10 +13,34 @@ describe "Foreman::Engine" do
 
     describe "with a Procfile" do
       before { write_procfile }
+      after  {
+        ENV['ERB_1'] = 'false'
+        ENV['ERB_2'] = 'false'
+      }
 
       it "reads the processes" do
         subject.processes["alpha"].command.should == "./alpha"
         subject.processes["bravo"].command.should == "./bravo"
+      end
+
+      it "reads the process with an an erb processor" do
+        ENV['ERB_1'] = 'true'
+        write_erb_procfile
+        subject.processes["alpha"].command.should == './erb1/alpha'
+        subject.processes["bravo"].command.should == './erb1/bravo'
+      end
+
+      it 'reads the process and uses a secondary configuration' do
+        ENV['ERB_2'] = 'true'
+        write_erb_procfile
+        subject.processes["alpha"].command.should == './erb2/alpha'
+        subject.processes["bravo"].command.should == './erb2/bravo'
+      end
+
+      it 'reads the process and uses a fallback configuration' do
+        write_erb_procfile
+        subject.processes["alpha"].command.should == './alpha'
+        subject.processes["bravo"].command.should == './bravo'
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,8 +26,27 @@ end
 
 def write_procfile(procfile="Procfile")
   File.open(procfile, "w") do |file|
+    file.puts "" # Check that a blank line does not blow things up
     file.puts "alpha: ./alpha"
     file.puts "bravo: ./bravo"
+  end
+  File.expand_path(procfile)
+end
+
+def write_erb_procfile(procfile="Procfile")
+  File.open(procfile, 'w') do |file|
+    file.puts <<-ERB
+      <% if ENV['ERB_1'] == 'true' %>
+        alpha: ./erb1/alpha
+        bravo: ./erb1/bravo
+      <% elsif ENV['ERB_2'] == 'true' %>
+        alpha: ./erb2/alpha
+        bravo: ./erb2/bravo
+      <% else %>
+        alpha: ./alpha
+        bravo: ./bravo
+      <% end %>
+    ERB
   end
   File.expand_path(procfile)
 end


### PR DESCRIPTION
Hi

I really love the idea of foreman. I've tried using bluepill, monit, god and been pretty dissapointed with all of them. I'm really looking forward to trying foreman in conjunction with silverline.  To do this though I need to be able to specify things like environment variables, and set unicorn configuration files etc.

I've added ERB pre-processing to procfiles as a first step towards allowing this to occur (note there is also a bugfix for blank lines). As an example:

<pre><code>
&lt;% if ENV['RAILS_ENV'] == 'production' || ENV['RAILS_ENV'] == 'beta' %&gt;
  web:            RAILS_ENV=&lt;%= ENV['RAILS_ENV'] %&gt; bundle exec unicorn -c config/unicorn.rb
  email-worker:   RAILS_ENV=&lt;%= ENV['RAILS_ENV'] %&gt; bundle exec rake resque:work QUEUE=email
  general-worker: RAILS_ENV=&lt;%= ENV['RAILS_ENV'] %&gt; bundle exec rake resque:work QUEUE=tasks,background,misc
&lt;% else %&gt;
  web: bundle exec unicorn -p $PORT
  worker: bundle exec rake resque:work QUEUE=*
&lt;% end %&gt;
</code></pre>


Whilst this may not be the case that you want to end up with eventually, it should allow for people to export, export with capistrano, run in development etc while you get something really awesome in place. I've always found that having ERB pre-processing in place to be handy in most situations anyway and is usually really helpful.

Cheers
Daniel
