### PR TITLE
Added --start-on-boot flag for "export upstart"

### DIFF
--- a/data/export/upstart/master.conf.erb
+++ b/data/export/upstart/master.conf.erb
@@ -1,3 +1,4 @@
+<%= "start on runlevel [2345]\n" if start_on_boot %>
 pre-start script
 
 bash << "EOF"

--- a/lib/foreman/cli.rb
+++ b/lib/foreman/cli.rb
@@ -26,11 +26,12 @@ class Foreman::CLI < Thor
 
   desc "export FORMAT LOCATION", "Export the application to another process management format"
 
-  method_option :app,         :type => :string,  :aliases => "-a"
-  method_option :log,         :type => :string,  :aliases => "-l"
-  method_option :port,        :type => :numeric, :aliases => "-p"
-  method_option :user,        :type => :string,  :aliases => "-u"
-  method_option :concurrency, :type => :string,  :aliases => "-c",
+  method_option :app,            :type => :string,  :aliases => "-a"
+  method_option :log,            :type => :string,  :aliases => "-l"
+  method_option :port,           :type => :numeric, :aliases => "-p"
+  method_option :user,           :type => :string,  :aliases => "-u"
+  method_option :start_on_boot,  :type => :boolean, :aliases => "-b"
+  method_option :concurrency,    :type => :string,  :aliases => "-c",
     :banner => '"alpha=5,bar=3"'
 
   def export(format, location=nil)

--- a/lib/foreman/export/upstart.rb
+++ b/lib/foreman/export/upstart.rb
@@ -11,6 +11,7 @@ class Foreman::Export::Upstart < Foreman::Export::Base
     app = options[:app] || File.basename(engine.directory)
     user = options[:user] || app
     log_root = options[:log] || "/var/log/#{app}"
+    start_on_boot = options[:start_on_boot]
 
     Dir["#{location}/#{app}*.conf"].each do |file|
       say "cleaning up: #{file}"

--- a/spec/foreman/export/upstart_spec.rb
+++ b/spec/foreman/export/upstart_spec.rb
@@ -11,14 +11,22 @@ describe Foreman::Export::Upstart do
   before(:each) { load_export_templates_into_fakefs("upstart") }
   before(:each) { stub(upstart).say }
 
-  it "exports to the filesystem" do
-    upstart.export("/tmp/init")
+  describe "exporting to the filesystem" do
+    it do
+      upstart.export("/tmp/init")
+  
+      File.read("/tmp/init/app.conf").should         == example_export_file("upstart/app-1.conf")
+      File.read("/tmp/init/app-alpha.conf").should   == example_export_file("upstart/app-alpha.conf")
+      File.read("/tmp/init/app-alpha-1.conf").should == example_export_file("upstart/app-alpha-1.conf")
+      File.read("/tmp/init/app-alpha-2.conf").should == example_export_file("upstart/app-alpha-2.conf")
+      File.read("/tmp/init/app-bravo.conf").should   == example_export_file("upstart/app-bravo.conf")
+      File.read("/tmp/init/app-bravo-1.conf").should == example_export_file("upstart/app-bravo-1.conf")
+    end
 
-    File.read("/tmp/init/app.conf").should         == example_export_file("upstart/app.conf")
-    File.read("/tmp/init/app-alpha.conf").should   == example_export_file("upstart/app-alpha.conf")
-    File.read("/tmp/init/app-alpha-1.conf").should == example_export_file("upstart/app-alpha-1.conf")
-    File.read("/tmp/init/app-alpha-2.conf").should == example_export_file("upstart/app-alpha-2.conf")
-    File.read("/tmp/init/app-bravo.conf").should   == example_export_file("upstart/app-bravo.conf")
-    File.read("/tmp/init/app-bravo-1.conf").should == example_export_file("upstart/app-bravo-1.conf")
+    it "with --start-on-boot" do
+      upstart.export("/tmp/init", :start_on_boot => true)
+
+      File.read("/tmp/init/app.conf").should == example_export_file("upstart/app-2.conf")
+    end
   end
 end

--- a/spec/resources/export/upstart/app-1.conf
+++ b/spec/resources/export/upstart/app-1.conf
@@ -1,0 +1,9 @@
+
+pre-start script
+
+bash << "EOF"
+  mkdir -p /var/log/app
+  chown -R app /var/log/app
+EOF
+
+end script

--- a/spec/resources/export/upstart/app-2.conf
+++ b/spec/resources/export/upstart/app-2.conf
@@ -1,3 +1,5 @@
+start on runlevel [2345]
+
 pre-start script
 
 bash << "EOF"


### PR DESCRIPTION
Added the --start-on-boot [-b] flag to Foreman's CLI for "export upstart". Using this option will add `start on runlevel [2345]` at the top of the generated `<app>.conf` file which will start all the processes for <app> when the system boots up so that you don't have to manually SSH in to your server to start the processes with `start <app>` after a server reboot / crash-recovery at a data center.
