### PR TITLE
Custom Templates ( --template [-t] )

### DIFF
--- a/lib/foreman/cli.rb
+++ b/lib/foreman/cli.rb
@@ -30,6 +30,7 @@ class Foreman::CLI < Thor
   method_option :log,         :type => :string,  :aliases => "-l"
   method_option :port,        :type => :numeric, :aliases => "-p"
   method_option :user,        :type => :string,  :aliases => "-u"
+  method_option :template,    :type => :string,  :aliases => "-t"
   method_option :concurrency, :type => :string,  :aliases => "-c",
     :banner => '"alpha=5,bar=3"'
 

--- a/lib/foreman/export/base.rb
+++ b/lib/foreman/export/base.rb
@@ -4,6 +4,7 @@ require "foreman/utils"
 class Foreman::Export::Base
 
   attr_reader :engine
+  attr_accessor :template
 
   def initialize(engine)
     @engine = engine
@@ -23,8 +24,12 @@ private ######################################################################
     puts "[foreman export] %s" % message
   end
 
-  def export_template(name)
-    File.read(File.expand_path("../../../../data/export/#{name}", __FILE__))
+  def export_template(path, file)
+    if template and File.exist?(file_path = File.join(template, file))
+      File.read(file_path)
+    else
+      File.read(File.expand_path("../../../../data/export/#{path}/#{file}", __FILE__))
+    end
   end
 
   def write_file(filename, contents)

--- a/lib/foreman/export/upstart.rb
+++ b/lib/foreman/export/upstart.rb
@@ -11,6 +11,7 @@ class Foreman::Export::Upstart < Foreman::Export::Base
     app = options[:app] || File.basename(engine.directory)
     user = options[:user] || app
     log_root = options[:log] || "/var/log/#{app}"
+    self.template = options[:template]
 
     Dir["#{location}/#{app}*.conf"].each do |file|
       say "cleaning up: #{file}"
@@ -19,14 +20,14 @@ class Foreman::Export::Upstart < Foreman::Export::Base
 
     concurrency = Foreman::Utils.parse_concurrency(options[:concurrency])
 
-    master_template = export_template("upstart/master.conf.erb")
+    master_template = export_template("upstart", "master.conf.erb")
     master_config   = ERB.new(master_template).result(binding)
     write_file "#{location}/#{app}.conf", master_config
 
-    process_template = export_template("upstart/process.conf.erb")
+    process_template = export_template("upstart", "process.conf.erb")
 
     engine.processes.values.each do |process|
-      process_master_template = export_template("upstart/process_master.conf.erb")
+      process_master_template = export_template("upstart", "process_master.conf.erb")
       process_master_config   = ERB.new(process_master_template).result(binding)
       write_file "#{location}/#{app}-#{process.name}.conf", process_master_config
 


### PR DESCRIPTION
Added the ability to use template configuration files using the '--template [-t]' command line option. This allows you to create a directory on the file system containing your configuration files which Foreman will read from instead of the default templates.

---

Hi David, here's an attempt at implementing custom template support in a simple way without significantly modifying the current code-base.

Basically what this allows you to do is to create a directory on the file system (for example `/upstart-templates`) and place these configuration files in them:
- master.conf.erb
- process_master.conf.erb
- process.conf.erb

These are the same template names that the foreman gem uses. You can either override 1, 2, or all 3 of these files. The ones that are not present in the custom template directory will be ignored, and it will default back to the Foreman default templates. This way, if you only want to adjust for example the `master.conf.erb` you don't have to write out all 3 template files. It would only use the custom `/upstart-templates/master.conf.erb` and the other 2 will come from Foreman's default templates.

Unfortunately I couldn't figure out how to get the tests working (due to the Fake File System thing). Though, this is a very small adjustment that integrates nicely in the current code-base. Maybe you could have a look and see if you could write up a test, if needed that is.

The CLI command:

```
foreman export upstart /etc/init --template /upstart-templates
foreman export upstart /etc/init -t /upstart-templates
```

Let me know what you think.

Cheers,
Michael van Rooijen
