### PR TITLE
A little convention over configuration love.

### DIFF
--- a/lib/foreman/export/base.rb
+++ b/lib/foreman/export/base.rb
@@ -26,7 +26,7 @@ private ######################################################################
   def export_template(exporter, file, template_root)
     if template_root && File.exist?(file_path = File.join(template_root, file))
       File.read(file_path)
-    elsif File.exist?(file_path = File.join("~/.foreman/", file))
+    elsif File.exist?(file_path = File.join("~/.foreman/templates", file))
       File.read(file_path)
     else
       File.read(File.expand_path("../../../../data/export/#{exporter}/#{file}", __FILE__))

--- a/spec/foreman/export/upstart_spec.rb
+++ b/spec/foreman/export/upstart_spec.rb
@@ -38,7 +38,7 @@ describe Foreman::Export::Upstart do
   end
 
   context "with alternate templates from home dir" do
-    let(:default_template_root) {File.expand_path("~/.foreman")}
+    let(:default_template_root) {File.expand_path("~/.foreman/templates")}
 
     before do
       FileUtils.mkdir_p default_template_root


### PR DESCRIPTION
tweaked the upstart export code so that it looks for templates in ~/.foreman if no template_root is specified.
