### PR TITLE
Blank line in Procfile breaks Foreman

### DIFF
--- a/lib/foreman/engine.rb
+++ b/lib/foreman/engine.rb
@@ -25,7 +25,7 @@ class Foreman::Engine
     @processes ||= begin
       @order = []
       procfile.split("\n").inject({}) do |hash, line|
-        next if line.strip == ""
+        next hash if line.strip == ""
         name, command = line.split(/ *: +/, 2)
         unless command
           warn_deprecated_procfile!

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,6 +27,7 @@ end
 def write_procfile(procfile="Procfile")
   File.open(procfile, "w") do |file|
     file.puts "alpha: ./alpha"
+    file.puts "\n"
     file.puts "bravo: ./bravo"
   end
   File.expand_path(procfile)


### PR DESCRIPTION
Hiya, using Mac OSX any blank lines break the Procfile, am pretty sure this will occur on any ruby though ? 

See this gist for an example ...

https://gist.github.com/1111359

I have attached a pull request containing fix and test.
