### PR TITLE
Fix for "..../lib/foreman/engine.rb:117:in `eof?': Input/output error - /dev/pts/n (Errno::EIO)" errors

### DIFF
--- a/lib/foreman/engine.rb
+++ b/lib/foreman/engine.rb
@@ -119,7 +119,7 @@ private ######################################################################
           end
         end
       end
-    rescue PTY::ChildExited, Interrupt
+    rescue PTY::ChildExited, Interrupt, Errno::EIO
       begin
         info "process exiting", process
       rescue Interrupt


### PR DESCRIPTION
add Errno::EIO to list of rescued exceptions as underlying pts can close before shutdown is complete

Possibly relates to GitHub Issue #40, but I cannot confirm.
