### PR TITLE
Read an env file from the users home dir

### DIFF
--- a/lib/foreman/engine.rb
+++ b/lib/foreman/engine.rb
@@ -178,6 +178,7 @@ private ######################################################################
     pid, status = Process.wait2
     process = running_processes.delete(pid)
     info "process terminated", process
+
     terminate_gracefully
     kill_all
   rescue Errno::ECHILD
@@ -203,9 +204,18 @@ private ######################################################################
 
   def read_environment(filename)
     error "No such file: #{filename}" if filename && !File.exists?(filename)
-    filename ||= ".env"
     environment = {}
+    if filename
+      environment = read_environment_file(filename,environment)
+    else
+      [File.join(ENV["HOME"],".foreman/env"), ".env"].each do |filename|
+        environment = read_environment_file(filename, environment)
+      end
+    end
+    environment
+  end
 
+  def read_environment_file(filename, environment)
     if File.exists?(filename)
       File.read(filename).split("\n").each do |line|
         if line =~ /\A([A-Za-z_]+)=(.*)\z/
@@ -213,7 +223,6 @@ private ######################################################################
         end
       end
     end
-
     environment
   end
 

--- a/spec/foreman/engine_spec.rb
+++ b/spec/foreman/engine_spec.rb
@@ -80,10 +80,18 @@ describe "Foreman::Engine" do
       subject.execute("alpha", :env => "/tmp/env")
     end
 
-    it "should read .env if none specified" do
-      File.open(".env", "w") { |f| f.puts("FOO=qoo") }
-      mock(subject).fork_individual(anything, anything, anything, { "FOO" => "qoo" })
-      subject.execute("bravo")
+    describe "with no env file specified" do
+      it "should read from the home directory" do
+        File.open("#{ENV["HOME"]}/.foreman/env", "w") { |f| f.puts("FOO=qoo") }
+        mock(subject).fork_individual(anything, anything, anything, { "FOO" => "qoo" })
+        subject.execute("bravo")
+      end
+
+      it "should read .env in current directory" do
+        File.open(".env", "w") { |f| f.puts("FOO=qoo") }
+        mock(subject).fork_individual(anything, anything, anything, { "FOO" => "qoo" })
+        subject.execute("bravo")
+      end
     end
   end
 end


### PR DESCRIPTION
This allows the user to specify a foreman env file that is applicable to
all their apps. This will be overwritten by an env file in a local
directory.

(context - we use rbenv to deploy rubies, but that means that the user's path ends up looking like "~/.rbenv/shims....". When deploying apps we'd like to preserve that in foreman, but don't want to have to write a .env file for each application)
