### PR TITLE
Log port + pid, plus expected # of workers for tools like Pow.

### DIFF
--- a/data/export/bluepill/master.pill.erb
+++ b/data/export/bluepill/master.pill.erb
@@ -4,7 +4,7 @@ Bluepill.application("<%= app %>", :foreground => false, :log_file => "/var/log/
   app.gid = "<%= user %>"
 
 <% engine.processes.values.each do |process| %>
-<% 1.upto(concurrency[process.name]) do |num| %>
+<% 1.upto(process.concurrency) do |num| %>
 <% port = engine.port_for(process, num, options[:port]) %>
   app.process("<%= process.name %>-<%=num%>") do |process|
     process.start_command = "<%= process.command.gsub("$PORT", port.to_s) %>"

--- a/lib/foreman/engine.rb
+++ b/lib/foreman/engine.rb
@@ -28,6 +28,7 @@ class Foreman::Engine
   def processes
     @processes ||= begin
       @order = []
+      concurrency = Foreman::Utils.parse_concurrency(@options[:concurrency])
       procfile.split("\n").inject({}) do |hash, line|
         next hash if line.strip == ""
         name, command = line.split(/\s*:\s+/, 2)
@@ -35,7 +36,7 @@ class Foreman::Engine
           warn_deprecated_procfile!
           name, command = line.split(/ +/, 2)
         end
-        process = Foreman::Process.new(name, command)
+        process = Foreman::Process.new(name, command, concurrency[name])
         process.color = next_color
         @order << process.name
         hash.update(process.name => process)
@@ -58,6 +59,10 @@ class Foreman::Engine
     proctitle "ruby: foreman master"
 
     processes_in_order.each do |name, process|
+      info "Launching #{process.concurrency} #{process.name} process#{process.concurrency > 1 ? "es" : ""}."
+    end
+
+    processes_in_order.each do |name, process|
       fork process
     end
 
@@ -69,7 +74,9 @@ class Foreman::Engine
 
   def execute(name)
 
-    fork processes[name]
+    process = processes[name]
+    info "Launching #{process.concurrency} #{process.name} process#{process.concurrency > 1 ? "es" : ""}."
+    fork process
 
     trap("TERM") { puts "SIGTERM received"; terminate_gracefully }
     trap("INT")  { puts "SIGINT received";  terminate_gracefully }
@@ -86,10 +93,7 @@ class Foreman::Engine
 private ######################################################################
 
   def fork(process)
-    concurrency = Foreman::Utils.parse_concurrency(@options[:concurrency])
-
-    info "Launching #{concurrency[process.name]} #{process.name} process#{concurrency[process.name] > 1 ? "es" : ""}."
-    1.upto(concurrency[process.name]) do |num|
+    1.upto(process.concurrency) do |num|
       fork_individual(process, num, port_for(process, num, @options[:port]))
     end
   end

--- a/lib/foreman/export/bluepill.rb
+++ b/lib/foreman/export/bluepill.rb
@@ -18,8 +18,6 @@ class Foreman::Export::Bluepill < Foreman::Export::Base
       FileUtils.rm(file)
     end
 
-    concurrency = Foreman::Utils.parse_concurrency(options[:concurrency])
-
     master_template = export_template("bluepill", "master.pill.erb", template_root)
     master_config   = ERB.new(master_template).result(binding)
     write_file "#{location}/#{app}.pill", master_config

--- a/lib/foreman/export/inittab.rb
+++ b/lib/foreman/export/inittab.rb
@@ -7,13 +7,11 @@ class Foreman::Export::Inittab < Foreman::Export::Base
     user = options[:user] || app
     log_root = options[:log] || "/var/log/#{app}"
 
-    concurrency = Foreman::Utils.parse_concurrency(options[:concurrency])
-
     inittab = []
     inittab << "# ----- foreman #{app} processes -----"
 
     engine.processes.values.inject(1) do |index, process|
-      1.upto(concurrency[process.name]) do |num|
+      1.upto(process.concurrency) do |num|
         id = app.slice(0, 2).upcase + sprintf("%02d", index)
         port = engine.port_for(process, num, options[:port])
         inittab << "#{id}:4:respawn:/bin/su - #{user} -c 'PORT=#{port} #{process.command} >> #{log_root}/#{process.name}-#{num}.log 2>&1'"

--- a/lib/foreman/export/upstart.rb
+++ b/lib/foreman/export/upstart.rb
@@ -18,8 +18,6 @@ class Foreman::Export::Upstart < Foreman::Export::Base
       FileUtils.rm(file)
     end
 
-    concurrency = Foreman::Utils.parse_concurrency(options[:concurrency])
-
     master_template = export_template("upstart", "master.conf.erb", template_root)
     master_config   = ERB.new(master_template).result(binding)
     write_file "#{location}/#{app}.conf", master_config
@@ -31,7 +29,7 @@ class Foreman::Export::Upstart < Foreman::Export::Base
       process_master_config   = ERB.new(process_master_template).result(binding)
       write_file "#{location}/#{app}-#{process.name}.conf", process_master_config
 
-      1.upto(concurrency[process.name]) do |num|
+      1.upto(process.concurrency) do |num|
         port = engine.port_for(process, num, options[:port])
         process_config = ERB.new(process_template).result(binding)
         write_file "#{location}/#{app}-#{process.name}-#{num}.conf", process_config

--- a/lib/foreman/process.rb
+++ b/lib/foreman/process.rb
@@ -4,11 +4,13 @@ class Foreman::Process
 
   attr_reader :name
   attr_reader :command
+  attr_reader :concurrency
   attr_accessor :color
 
-  def initialize(name, command)
+  def initialize(name, command, concurrency)
     @name    = name
     @command = command
+    @concurrency = concurrency
   end
 
 end

--- a/lib/foreman/utils.rb
+++ b/lib/foreman/utils.rb
@@ -3,12 +3,10 @@ require "foreman"
 class Foreman::Utils
 
   def self.parse_concurrency(concurrency)
-    @concurrency ||= begin
-      pairs = concurrency.to_s.gsub(/\s/, "").split(",")
-      pairs.inject(Hash.new(1)) do |hash, pair|
-        process, amount = pair.split("=")
-        hash.update(process => amount.to_i)        
-      end
+    pairs = concurrency.to_s.gsub(/\s/, "").split(",")
+    pairs.inject(Hash.new(1)) do |hash, pair|
+      process, amount = pair.split("=")
+      hash.update(process => amount.to_i)        
     end
   end
 

--- a/spec/foreman/engine_spec.rb
+++ b/spec/foreman/engine_spec.rb
@@ -37,6 +37,7 @@ describe "Foreman::Engine" do
   describe "start" do
     it "forks the processes" do
       write_procfile
+      stub(subject).info
       mock(subject).fork(subject.processes["alpha"])
       mock(subject).fork(subject.processes["bravo"])
       mock(subject).watch_for_termination
@@ -58,11 +59,13 @@ describe "Foreman::Engine" do
 
       engine.start
     end
+
   end
 
   describe "execute" do
     it "runs the processes" do
       write_procfile
+      mock(subject).info("Launching 1 alpha process.")
       mock(subject).fork(subject.processes["alpha"])
       mock(subject).watch_for_termination
       subject.execute("alpha")

--- a/spec/foreman/export/bluepill_spec.rb
+++ b/spec/foreman/export/bluepill_spec.rb
@@ -5,7 +5,7 @@ require "tmpdir"
 
 describe Foreman::Export::Bluepill do
   let(:procfile) { FileUtils.mkdir_p("/tmp/app"); write_procfile("/tmp/app/Procfile") }
-  let(:engine) { Foreman::Engine.new(procfile) }
+  let(:engine) { Foreman::Engine.new(procfile, :concurrency => "alpha=2") }
   let(:bluepill) { Foreman::Export::Bluepill.new(engine) }
 
   before(:each) { load_export_templates_into_fakefs("bluepill") }

--- a/spec/foreman/export/upstart_spec.rb
+++ b/spec/foreman/export/upstart_spec.rb
@@ -5,7 +5,7 @@ require "tmpdir"
 
 describe Foreman::Export::Upstart do
   let(:procfile) { FileUtils.mkdir_p("/tmp/app"); write_procfile("/tmp/app/Procfile") }
-  let(:engine) { Foreman::Engine.new(procfile) }
+  let(:engine) { Foreman::Engine.new(procfile, :concurrency => "alpha=2") }
   let(:upstart) { Foreman::Export::Upstart.new(engine) }
 
   before(:each) { load_export_templates_into_fakefs("upstart") }


### PR DESCRIPTION
Needed to support other tools finding the PID and ports of web processes
launched by Foreman. Specifically needed in order for Pow to launch
Foreman apps.
