### PR TITLE
Allow export using a specified environment file, using the --env or -e option

### DIFF
--- a/lib/foreman/cli.rb
+++ b/lib/foreman/cli.rb
@@ -28,6 +28,7 @@ class Foreman::CLI < Thor
 
   method_option :app,         :type => :string,  :aliases => "-a"
   method_option :log,         :type => :string,  :aliases => "-l"
+  method_option :env,         :type => :string,  :aliases => "-e", :desc => "Specify an environment file to load, defaults to .env"
   method_option :port,        :type => :numeric, :aliases => "-p"
   method_option :user,        :type => :string,  :aliases => "-u"
   method_option :template,    :type => :string,  :aliases => "-t"


### PR DESCRIPTION
The `--env` options was missing from `foreman export`.  I've not added a test as I couldn't see any existing tests for command line options.  The `engine_spec` test already tests that the engine respects the `--env` option.
