### PR TITLE
Eliminate dead code

### DIFF
--- a/lib/foreman/engine.rb
+++ b/lib/foreman/engine.rb
@@ -225,10 +225,6 @@ private ######################################################################
     end
   end
 
-  def runner
-    File.expand_path("../../../bin/foreman-runner", __FILE__)
-  end
-
   def terminate_gracefully
     info "sending SIGTERM to all processes"
     kill_all "SIGTERM"


### PR DESCRIPTION
An oversight; this code should probably have been pruned in
20e598abcce655f1952c0eedea89e11ea5c7c384.

Signed-off-by: Dan Farina drfarina@acm.org
