### PR TITLE
Documentation of new process name restrictions

### DIFF
--- a/man/foreman.1
+++ b/man/foreman.1
@@ -132,7 +132,7 @@ job: bundle exec rake jobs:work
 .IP "" 0
 .
 .P
-You can validate your Procfile format using the \fBcheck\fR command
+Process name may only contain letters, numbers and the underscore _ character. You can validate your Procfile format using the \fBcheck\fR command
 .
 .IP "" 4
 .

--- a/man/foreman.1.ronn
+++ b/man/foreman.1.ronn
@@ -113,7 +113,7 @@ to run it.
     web: bundle exec thin start
     job: bundle exec rake jobs:work
 
-You can validate your Procfile format using the `check` command
+Process name may only contain letters, numbers and the underscore _ character.You can validate your Procfile format using the `check` command
 
     $ foreman check
 


### PR DESCRIPTION
Versions prior to 0.24 (prior to commit d26ca669a15e9a853236082fd76d9e4018d42c1d) accepted other process name formats. This commit include the new restrictions in documentation.

Many thanks!
Marcos.
