### PR TITLE
Controlling exception on ruby1.9.3-Head 

### DIFF
--- a/lib/foreman/engine.rb
+++ b/lib/foreman/engine.rb
@@ -96,7 +96,7 @@ private ######################################################################
           end
         end
       end
-    rescue PTY::ChildExited, Interrupt, Errno::EIO
+    rescue PTY::ChildExited, Interrupt, Errno::EIO, Errno::ENOENT
       begin
         info "process exiting", process
       rescue Interrupt


### PR DESCRIPTION
Controlling the exception when a command doesn't exist in ruby1.9.3
