### PR TITLE
Removed memoization [Foreman::Utils.parse_concurrency]

### DIFF
--- a/lib/foreman/utils.rb
+++ b/lib/foreman/utils.rb
@@ -3,7 +3,7 @@ require "foreman"
 class Foreman::Utils
 
   def self.parse_concurrency(concurrency)
-    @concurrency ||= begin
+    begin
       pairs = concurrency.to_s.gsub(/\s/, "").split(",")
       pairs.inject(Hash.new(1)) do |hash, pair|
         process, amount = pair.split("=")

--- a/spec/foreman/export/bluepill_spec.rb
+++ b/spec/foreman/export/bluepill_spec.rb
@@ -12,7 +12,7 @@ describe Foreman::Export::Bluepill do
   before(:each) { stub(bluepill).say }
 
   it "exports to the filesystem" do
-    bluepill.export("/tmp/init")
+    bluepill.export("/tmp/init", :concurrency => "alpha=2")
     
     File.read("/tmp/init/app.pill").should == example_export_file("bluepill/app.pill")
   end

--- a/spec/foreman/export/upstart_spec.rb
+++ b/spec/foreman/export/upstart_spec.rb
@@ -12,7 +12,7 @@ describe Foreman::Export::Upstart do
   before(:each) { stub(upstart).say }
 
   it "exports to the filesystem" do
-    upstart.export("/tmp/init")
+    upstart.export("/tmp/init", :concurrency => "alpha=2")
 
     File.read("/tmp/init/app.conf").should         == example_export_file("upstart/app.conf")
     File.read("/tmp/init/app-alpha.conf").should   == example_export_file("upstart/app-alpha.conf")


### PR DESCRIPTION
Hi!

Was working on feature branch and I ran into a issue where the specs would pass en-mass but not individually.

This should fix that problem.

Cheers,
Chris 
