### PR TITLE
Set executable bit on runit run scripts.

### DIFF
--- a/lib/foreman/export/runit.rb
+++ b/lib/foreman/export/runit.rb
@@ -29,6 +29,7 @@ class Foreman::Export::Runit < Foreman::Export::Base
         
         run = ERB.new(run_template).result(binding)
         write_file "#{process_directory}/run", run
+        FileUtils.chmod 0744, "#{process_directory}/run"
         
         port = engine.port_for(process, num, options[:port])
         environment_variables = {'PORT' => port}.
@@ -41,6 +42,7 @@ class Foreman::Export::Runit < Foreman::Export::Base
         
         log_run = ERB.new(log_run_template).result(binding)
         write_file "#{process_log_directory}/run", log_run
+        FileUtils.chmod 0744, "#{process_log_directory}/run"
         
       end
     end

--- a/spec/foreman/export/runit_spec.rb
+++ b/spec/foreman/export/runit_spec.rb
@@ -10,6 +10,7 @@ describe Foreman::Export::Runit do
   
   before(:each) { load_export_templates_into_fakefs("runit") }
   before(:each) { stub(runit).say }
+  before(:each) { stub(FakeFS::FileUtils).chmod }
   
   it "exports to the filesystem" do
     FileUtils.mkdir_p('/tmp/init')


### PR DESCRIPTION
Just ran into an issue in production. The 'run' scripts exported for runit actually need to be executable, else it won't work.

Not really happy with the test though. The problem is that FakeFS lacks support for FileUtils.chmod and Stat#mode, so this is a quick stub. It doesn't verify any expectation. 
