### PR TITLE
Try to use a reasonable distribution of colours for larger Procfiles

### DIFF
--- a/lib/foreman/engine.rb
+++ b/lib/foreman/engine.rb
@@ -172,7 +172,8 @@ private ######################################################################
   def next_color
     @current_color ||= -1
     @current_color  +=  1
-    @current_color >= COLORS.length ? "" : COLORS[@current_color]
+    @current_color = 0 if COLORS.length < @current_color
+    COLORS[@current_color]
   end
 
   def read_environment_files(filenames)


### PR DESCRIPTION
We're running 10+ applications using Foreman. The colours for the first 5 applications are really useful, but beyond the first 5 each application logs in green which makes it harder to notice different applications logging.

I've added two more colours from `Term::ANSIColor`, blue and white, and made `next_color` loop around to the start of the `COLOR` array when it gets to the end. It's not a perfect solution, we'll still get overlapping colours, but hopefully not quite so many.
