### PR TITLE
Added option to specify application root directory, when executing a Procfile from a different location

### DIFF
--- a/lib/foreman/cli.rb
+++ b/lib/foreman/cli.rb
@@ -7,6 +7,7 @@ require "yaml"
 class Foreman::CLI < Thor
 
   class_option :procfile, :type => :string, :aliases => "-f", :desc => "Default: Procfile"
+  class_option :app_root, :type => :string, :aliases => "-d", :desc => "Default: Procfile directory"
 
   desc "start [PROCESS]", "Start the application, or a specific process"
 

--- a/lib/foreman/engine.rb
+++ b/lib/foreman/engine.rb
@@ -21,7 +21,7 @@ class Foreman::Engine
 
   def initialize(procfile, options={})
     @procfile  = Foreman::Procfile.new(procfile)
-    @directory = File.expand_path(File.dirname(procfile))
+    @directory = options[:app_root] || File.expand_path(File.dirname(procfile))
     @options = options
     @environment = read_environment_files(options[:env])
   end


### PR DESCRIPTION
I just discovered the LiveReload gem, and wanted to use foreman to help me set up my development environments.

I didn't want to check in my custom development Procfiles, so I needed to alter the behaviour of:

> [The Procfile's] containing directory will be assumed to be the root directory of the application.

I've set up some shared `Procfiles` for development, such as `Rails3Dev`, `Rails31Dev`, `JekyllDev`, etc.

Then I set up a bash alias for each of these Procfiles, such as:

``` bash
alias rd31="foreman start -d . -f ~/dev/procfiles/Rails31Dev"
```

The only thing missing was the `-d` flag. 

My `Rails31Dev` file looks like this:

``` yaml
compass: compass watch --sass-dir app/assets/stylesheets --css-dir public/assets
livereload: livereload
passenger: passenger start
```

Thanks!
