### PR TITLE
Expand template path under user's home directory (foreman export).

### DIFF
--- a/lib/foreman/export/base.rb
+++ b/lib/foreman/export/base.rb
@@ -26,7 +26,7 @@ private ######################################################################
   def export_template(exporter, file, template_root)
     if template_root && File.exist?(file_path = File.join(template_root, file))
       File.read(file_path)
-    elsif File.exist?(file_path = File.join("~/.foreman/templates", file))
+    elsif File.exist?(file_path = File.expand_path(File.join("~/.foreman/templates", file)))
       File.read(file_path)
     else
       File.read(File.expand_path("../../../../data/export/#{exporter}/#{file}", __FILE__))

--- a/spec/foreman/export/upstart_spec.rb
+++ b/spec/foreman/export/upstart_spec.rb
@@ -38,11 +38,17 @@ describe Foreman::Export::Upstart do
   end
 
   context "with alternate templates from home dir" do
-    let(:default_template_root) {File.expand_path("~/.foreman/templates")}
+    let(:default_template_root) {File.expand_path("#{ENV['HOME']}/.foreman/templates")}
 
     before do
+      ENV['_FOREMAN_SPEC_HOME'] = ENV['HOME']
+      ENV['HOME'] = "/home/appuser"
       FileUtils.mkdir_p default_template_root
       File.open("#{default_template_root}/master.conf.erb", "w") { |f| f.puts "default_alternate_template" }
+    end
+
+    after do
+      ENV['HOME'] = ENV.delete('_FOREMAN_SPEC_HOME')
     end
 
     it "can export with alternate template files" do


### PR DESCRIPTION
Hi David, love this library but I ran into a use case that wasn't quite behaving correctly. Unfortunately, the FakeFS gem is helping to cloak this problem so the specs continue to pass in 1.9.3/1.9.2/1.8.7 with or without the spec code updates. Here's the crib notes:
- File.join won't expand `~` into `ENV['HOME']`
  (http://ruby-doc.org/core-1.9.3/File.html#method-c-expand_path)
- The FakeFS File.exists? implementation calls [FileSystem#find](https://github.com/defunkt/fakefs/blob/master/lib/fakefs/file_system.rb#L22-33)
  containing a call to [FileSystem#normalize_path](https://github.com/defunkt/fakefs/blob/master/lib/fakefs/file_system.rb#L91-98) which expands the
  path variable passed in
- The file system mocking library sets up a false expectation that `~`
  will be expanded in the #export_template method and consequently the
  production code can't use the template directory
- To guard against future regressions such as fixes/updates to FakeFS or
  using an alternate file system mocking library, the specs were updated
  to explicitly set `ENV['HOME']`

Thanks again, and kudos on your quick and frequent releases!
