### PR TITLE
Fixed 'invalid byte sequence in US-ASCII' error with Rails application output

### DIFF
--- a/bin/foreman
+++ b/bin/foreman
@@ -1,5 +1,8 @@
 #!/usr/bin/env ruby
 
+Encoding.default_external = Encoding::UTF_8
+Encoding.default_internal = Encoding::UTF_8
+
 $:.unshift File.expand_path("../../lib", __FILE__)
 
 require "foreman/cli"


### PR DESCRIPTION
Hello David,

I've added couple of string to the main foreman script because it started to fault with above error on some Rails app actions. Such as create or update.

Foreman faults with such traceback:

```
01:58:38 rails.1   | Started POST "/notes" for 127.0.0.1 at 2012-01-17 01:58:27 +0400
01:58:38 rails.1   | Processing by NotesController#create as HTML
invalid byte sequence in US-ASCII
/Users/cr0t/.rvm/gems/ruby-1.9.3-p0@qippo/gems/foreman-0.34.1/lib/foreman/engine.rb:96:in `split'
/Users/cr0t/.rvm/gems/ruby-1.9.3-p0@qippo/gems/foreman-0.34.1/lib/foreman/engine.rb:96:in `block (3 levels) in watch_for_output'
/Users/cr0t/.rvm/gems/ruby-1.9.3-p0@qippo/gems/foreman-0.34.1/lib/foreman/engine.rb:95:in `each'
/Users/cr0t/.rvm/gems/ruby-1.9.3-p0@qippo/gems/foreman-0.34.1/lib/foreman/engine.rb:95:in `block (2 levels) in watch_for_output'
/Users/cr0t/.rvm/gems/ruby-1.9.3-p0@qippo/gems/foreman-0.34.1/lib/foreman/engine.rb:93:in `loop'
/Users/cr0t/.rvm/gems/ruby-1.9.3-p0@qippo/gems/foreman-0.34.1/lib/foreman/engine.rb:93:in `block in watch_for_output'
```

I think that happened because foreman itself runs with US-ASCII internal and external encoding, but Rails output contains UTF characters, such as default utf8 rails form parameter:

```
Parameters: {"utf8"=>"✓",...
```
## 

Best regards,
Sergey Kuznetsov.
