### PR TITLE
runit creates a full path to export directory.

### DIFF
--- a/lib/foreman/export/runit.rb
+++ b/lib/foreman/export/runit.rb
@@ -51,7 +51,7 @@ class Foreman::Export::Runit < Foreman::Export::Base
   private
   def create_directory(location)
     say "creating: #{location}"
-    FileUtils.mkdir(location)
+    FileUtils.mkdir_p(location)
   end
 
   def inline_variables(command)

--- a/spec/foreman/export/runit_spec.rb
+++ b/spec/foreman/export/runit_spec.rb
@@ -33,4 +33,8 @@ describe Foreman::Export::Runit do
         example_export_file('runit/app-bravo-1-log-run')
     File.read("/tmp/init/app-bravo-1/env/PORT").should == "5100\n"
   end
+
+  it "creates a full path to the export directory" do
+    expect { runit.export('/tmp/init', :concurrency => "alpha=2,bravo=1") }.to_not raise_error(Errno::ENOENT)
+  end
 end


### PR DESCRIPTION
Simple enough, but this helps when re-exporting runit services. Cheers, and thanks!
