### PR TITLE
Upstart explicit SIGTERM to children

### DIFF
--- a/data/export/upstart/process.conf.erb
+++ b/data/export/upstart/process.conf.erb
@@ -2,4 +2,4 @@ start on starting <%= app %>-<%= process.name %>
 stop on stopping <%= app %>-<%= process.name %>
 respawn
 
-exec su - <%= user %> --shell=/bin/bash -c 'cd <%= engine.directory %>; trap '\''kill $(jobs -p)'\'' EXIT; export PORT=<%= port %>;<% engine.environment.each_pair do |var,env| %> export <%= var.upcase %>=<%= env %>; <% end %> <%= process.command %> >> <%= log_root %>/<%=process.name%>-<%=num%>.log 2>&1'
+exec su - <%= user %> --shell=/bin/bash -c 'cd <%= engine.directory %>; trap '\''kill -QUIT $(jobs -p)'\'' EXIT; export PORT=<%= port %>;<% engine.environment.each_pair do |var,env| %> export <%= var.upcase %>=<%= env %>; <% end %> <%= process.command %> >> <%= log_root %>/<%=process.name%>-<%=num%>.log 2>&1'

--- a/spec/resources/export/upstart/app-alpha-1.conf
+++ b/spec/resources/export/upstart/app-alpha-1.conf
@@ -2,4 +2,4 @@ start on starting app-alpha
 stop on stopping app-alpha
 respawn
 
-exec su - app --shell=/bin/bash -c 'cd /tmp/app; trap '\''kill $(jobs -p)'\'' EXIT; export PORT=5000; ./alpha >> /var/log/app/alpha-1.log 2>&1'
+exec su - app --shell=/bin/bash -c 'cd /tmp/app; trap '\''kill -QUIT $(jobs -p)'\'' EXIT; export PORT=5000; ./alpha >> /var/log/app/alpha-1.log 2>&1'

--- a/spec/resources/export/upstart/app-alpha-2.conf
+++ b/spec/resources/export/upstart/app-alpha-2.conf
@@ -2,4 +2,4 @@ start on starting app-alpha
 stop on stopping app-alpha
 respawn
 
-exec su - app --shell=/bin/bash -c 'cd /tmp/app; trap '\''kill $(jobs -p)'\'' EXIT; export PORT=5001; ./alpha >> /var/log/app/alpha-2.log 2>&1'
+exec su - app --shell=/bin/bash -c 'cd /tmp/app; trap '\''kill -QUIT $(jobs -p)'\'' EXIT; export PORT=5001; ./alpha >> /var/log/app/alpha-2.log 2>&1'

--- a/spec/resources/export/upstart/app-bravo-1.conf
+++ b/spec/resources/export/upstart/app-bravo-1.conf
@@ -2,4 +2,4 @@ start on starting app-bravo
 stop on stopping app-bravo
 respawn
 
-exec su - app --shell=/bin/bash -c 'cd /tmp/app; trap '\''kill $(jobs -p)'\'' EXIT; export PORT=5100; ./bravo >> /var/log/app/bravo-1.log 2>&1'
+exec su - app --shell=/bin/bash -c 'cd /tmp/app; trap '\''kill -QUIT $(jobs -p)'\'' EXIT; export PORT=5100; ./bravo >> /var/log/app/bravo-1.log 2>&1'


### PR DESCRIPTION
As per issue #97, the Upstart scripts generated by Foreman don't always kill the running process, because they rely on children dying when the parent exits.

This patch does two things:
1. It introduces a `$` for all process executions. According to the [Upstart documentation](http://upstart.ubuntu.com/getting-started.html) for `exec`:
   
   > any special characters (e.g. quotes or ‘$’) will result in the command being passed to a shell for interpretation
   
   As a result, all processes will be wrapped by bash (not just the ones using `$PORT`).
2. It traps the bash script exit, and generates a `SIGTERM` to all processes in the process group.

I've tested this fix with [uWSGI](http://projects.unbit.it/uwsgi/) (inside a wrapper to handle uWSGI's [interesting interpretation of SIGKILL](http://projects.unbit.it/uwsgi/wiki/uWSGISignals)) and it works well.
