### PR TITLE
Using spoon for JRuby support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,10 @@ source "http://rubygems.org"
 
 gemspec
 
+platform :jruby do
+  gem 'spoon', '~> 0.0.1'
+end
+
 group :development do
   gem 'parka'
   gem 'rake'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,6 @@ PATH
   remote: .
   specs:
     foreman (0.36.1)
-      spoon (~> 0.0.1)
       term-ansicolor (~> 1.0.7)
       thor (>= 0.13.6)
 
@@ -65,3 +64,4 @@ DEPENDENCIES
   rr (~> 1.0.2)
   rspec (~> 2.0)
   rubyzip
+  spoon (~> 0.0.1)

--- a/foreman.gemspec
+++ b/foreman.gemspec
@@ -18,5 +18,4 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'term-ansicolor', '~> 1.0.7'
   gem.add_dependency 'thor',           '>= 0.13.6'
-  gem.add_dependency 'spoon',          '~> 0.0.1'
 end


### PR DESCRIPTION
Fixes #2

This is my first patch for JRuby, so any feedback would be appreciated. The specs do not run (I'll file a separate issue) but I am able to successfully start up & run the contents of a `Procfile`.

I based this patch on [launchy's JRuby support](https://github.com/copiousfreetime/launchy/pull/10) and I too confirmed these changes did not break 1.8.7, 1.9.2 or 1.9.3.
