### PR TITLE
Fix bash string comparision

### DIFF
--- a/bin/runner
+++ b/bin/runner
@@ -29,7 +29,7 @@ shift $((OPTIND-1))
 
 command=$1
 
-if [ "$1" == "" ]; then
+if [ -z "$1" ]; then
   usage
 fi
 


### PR DESCRIPTION
The current approach didn't work out to well, the comparision ends up to be:
[ gunicorn_django -k gevent -b 0.0.0.0:5000 -w 3 rcalapp/settings.py ==  ]
Which emits this warning:
/var/lib/gems/1.9.1/gems/foreman-0.37.0.pre3/bin/runner: 33: [: gunicorn_django -k gevent -b 0.0.0.0:5000 -w 3 rcalapp/settings.py: unexpected operator
