### PR TITLE
Provide a useful error if `foreman check` fails to find a Procfile

### DIFF
--- a/lib/foreman/cli.rb
+++ b/lib/foreman/cli.rb
@@ -54,6 +54,7 @@ class Foreman::CLI < Thor
   desc "check", "Validate your application's Procfile"
 
   def check
+    check_procfile!
     error "no processes defined" unless engine.procfile.entries.length > 0
     puts "valid procfile detected (#{engine.procfile.process_names.join(', ')})"
   end

--- a/spec/foreman/cli_spec.rb
+++ b/spec/foreman/cli_spec.rb
@@ -120,6 +120,14 @@ describe "Foreman::CLI", :fakefs do
         end
       end
     end
+
+    describe "without a Procfile" do
+      it "displays an error" do
+        mock_error(subject, "Procfile does not exist.") do
+          subject.check
+        end
+      end
+    end
   end
 
   describe "run" do


### PR DESCRIPTION
Fixes #152
