### PR TITLE
(Also) allow hashes in engine definitions

### DIFF
--- a/lib/foreman/engine.rb
+++ b/lib/foreman/engine.rb
@@ -20,8 +20,13 @@ class Foreman::Engine
              intense_cyan, intense_yellow, intense_green, intense_magenta,
              intense_red, intense_blue ]
 
-  def initialize(procfile, options={})
-    @procfile  = Foreman::Procfile.new(procfile)
+  def initialize(procfile, options={})  
+    @procfile = if procfile.is_a?(Hash)
+      raise "No :app_root specified" unless options[:app_root]
+      Foreman::Procfile.new(procfile.map { |k,v| Foreman::ProcfileEntry.new k, v })
+    else
+      Foreman::Procfile.new(procfile)
+    end    
     @directory = options[:app_root] || File.expand_path(File.dirname(procfile))
     @options = options.dup
     @environment = read_environment_files(options[:env])

--- a/lib/foreman/procfile.rb
+++ b/lib/foreman/procfile.rb
@@ -13,8 +13,8 @@ class Foreman::Procfile
 
   attr_reader :entries
 
-  def initialize(filename)
-    @entries = parse_procfile(filename)
+  def initialize(filename_or_entries)
+    @entries = filename_or_entries.is_a?(Array) ? filename_or_entries : parse_procfile(filename_or_entries)
   end
 
   def [](name)

--- a/spec/foreman/engine_spec.rb
+++ b/spec/foreman/engine_spec.rb
@@ -26,6 +26,22 @@ describe "Foreman::Engine", :fakefs do
         subject.procfile["bravo"].command.should == "./bravo"
       end
     end
+    
+    describe "with a Hash as Procfile" do
+
+      subject { Foreman::Engine.new({ 'gamma' => './gamma', 'delta' => './delta' }, { :app_root => __FILE__ }) }
+      
+      it "reads the processes" do
+        subject.procfile["gamma"].command.should == "./gamma"
+        subject.procfile["delta"].command.should == "./delta"
+      end
+      
+      it "requires the presence of the app_root option" do
+        lambda { Foreman::Engine.new({'gamma' => './gamma', 'delta' => './delta'}, {}) }.should raise_error
+      end
+      
+    end
+    
   end
 
   describe "start" do


### PR DESCRIPTION
This makes it easy to use foreman programmatically (e.g. in Rake tasks) like this (example assumes to reside in this forks root directory and [watch](http://linux.die.net/man/1/watch) being available on $PATH):

``` ruby
$:.unshift 'lib'
require 'foreman'
require 'foreman/engine'

`touch watch.tmp`

procs = {
  'watch' => 'watch ls -l >> watch.tmp',
  'tail' => 'tail -f watch.tmp'
}

engine = Foreman::Engine.new procs, :app_root => File.dirname(__FILE__)
engine.start
```
