### PR TITLE
list of ports to other languages added to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ Manage Procfile-based applications
 * [wiki](http://github.com/ddollar/foreman/wiki)
 * [changelog](https://github.com/ddollar/foreman/blob/master/Changelog.md)
 
+## Ports
+
+* [shoreman](https://github.com/hecticjeff/shoreman) - shell
+* [honcho](https://github.com/nickstenning/honcho) - python
+* [norman](https://github.com/josh/norman) - node.js
+
 ## Authors
 
 #### Created and maintained by


### PR DESCRIPTION
it looks like people have developed ports for shell, python and node.js (at least those i've seen so far) and i guess this information may come useful for those who prefer to use them over ruby implementation...
