### PR TITLE
Quote and escape environment variables in upstart templates

### DIFF
--- a/data/export/upstart/process.conf.erb
+++ b/data/export/upstart/process.conf.erb
@@ -2,4 +2,4 @@ start on starting <%= app %>-<%= process.name %>
 stop on stopping <%= app %>-<%= process.name %>
 respawn
 
-exec su - <%= user %> -c 'cd <%= engine.directory %>; export PORT=<%= port %>;<% engine.environment.each_pair do |var,env| %> export <%= var.upcase %>=<%= env %>; <% end %> <%= process.command %> >> <%= log_root %>/<%=process.name%>-<%=num%>.log 2>&1'
+exec su - <%= user %> -c 'cd <%= engine.directory %>; export PORT=<%= port %>;<% engine.environment.each_pair do |var,env| %> export <%= var.upcase %>=<%= shell_quote(env) %>; <% end %> <%= process.command %> >> <%= log_root %>/<%=process.name%>-<%=num%>.log 2>&1'

--- a/lib/foreman/export/base.rb
+++ b/lib/foreman/export/base.rb
@@ -48,4 +48,19 @@ private ######################################################################
     end
   end
 
+  # Quote a string to be used on the command line. Backslashes are escapde to \\ and quotes 
+  # escaped to \"
+  #
+  #   str - string to be quoted
+  #
+  # Examples
+  # 
+  #  shell_quote("FB|123\"\\1")
+  #  # => "\"FB|123\"\\"\\\\1\""
+  #
+  # Returns the the escaped string surrounded by quotes 
+  def shell_quote(str)
+    "\"#{str.gsub(/\\/){ '\\\\' }.gsub(/["]/){ "\\\"" }}\""
+  end
+
 end

--- a/spec/foreman/export/upstart_spec.rb
+++ b/spec/foreman/export/upstart_spec.rb
@@ -33,6 +33,12 @@ describe Foreman::Export::Upstart, :fakefs do
     upstart.export
   end
 
+  it "quotes and escapes environment variables" do
+    engine.environment['KEY'] = 'd"\|d'
+    upstart.export
+    File.read("/tmp/init/app-alpha-1.conf").should include('KEY="d\"\\\\|d"')
+  end
+
   context "with concurrency" do
     let(:options) { Hash[:concurrency => "alpha=2"] }
 


### PR DESCRIPTION
It's quite possible for an app's environment to contain shell unfriendly data. When exporting templates, the environment values should be escaped so MYVAR="value|with|pipes" or MYVAR="value\|with\|backslash"

Only upstart is updated in this patch but if the concept is sound I can fix any other exporters that require it.
