### PR TITLE
Resolve issue #167 "Foreman is ignoring the PORT environment variable."

### DIFF
--- a/lib/foreman/engine.rb
+++ b/lib/foreman/engine.rb
@@ -84,7 +84,7 @@ private ######################################################################
   end
 
   def base_port
-    options[:port] || 5000
+    options[:port] || @environment['PORT'] || 5000
   end
 
   def kill_all(signal="SIGTERM")

--- a/spec/foreman/engine_spec.rb
+++ b/spec/foreman/engine_spec.rb
@@ -134,4 +134,13 @@ describe "Foreman::Engine", :fakefs do
       subject.send(:poll_readers)
     end
   end
+
+  describe "base_port" do
+    it "should use environment if no option exists" do
+      write_procfile
+      File.open("/tmp/env", "w") { |f| f.puts("PORT=3000") }
+      engine = Foreman::Engine.new("Procfile", :env => "/tmp/env")
+      engine.send(:base_port).should == "3000"
+    end
+  end
 end


### PR DESCRIPTION
When a port is specified in an environment file it never gets used because it would only check the options or use port 5000. This change makes it check the environment hash before it drops to the default port of 5000.
