### PR TITLE
Guard against missing Procfile in engine.rb

### DIFF
--- a/lib/foreman/engine.rb
+++ b/lib/foreman/engine.rb
@@ -21,7 +21,7 @@ class Foreman::Engine
   Foreman::Color.enable($stdout)
 
   def initialize(procfile, options={})
-    @procfile  = Foreman::Procfile.new(procfile)
+    @procfile  = Foreman::Procfile.new(procfile) if File.exists?(procfile)
     @directory = options[:app_root] || File.expand_path(File.dirname(procfile))
     @options = options.dup
     @output_mutex = Mutex.new


### PR DESCRIPTION
Should be able to 'foreman run <task>' without a Procfile.  This seems true to the orig. intent as the cli does not directly check with 'run' (as it  does for 'start').
