### PR TITLE
Remove spec obsoleted by 91a8704

### DIFF
--- a/spec/foreman/engine_spec.rb
+++ b/spec/foreman/engine_spec.rb
@@ -12,12 +12,6 @@ describe "Foreman::Engine", :fakefs do
   end
 
   describe "initialize" do
-    describe "without an existing Procfile" do
-      it "raises an error" do
-        lambda { subject }.should raise_error
-      end
-    end
-
     describe "with a Procfile" do
       before { write_procfile }
 


### PR DESCRIPTION
The commit that made a Procfile optional made the 'without an existing Procfile' spec obsolete, so this patch just removes it.
