### PR TITLE
Add Procfile load/write/append API

### DIFF
--- a/lib/foreman/procfile.rb
+++ b/lib/foreman/procfile.rb
@@ -13,8 +13,9 @@ class Foreman::Procfile
 
   attr_reader :entries
 
-  def initialize(filename)
-    @entries = parse_procfile(filename)
+  def initialize(filename=nil)
+    @entries = []
+    load(filename) if filename
   end
 
   def [](name)
@@ -25,12 +26,31 @@ class Foreman::Procfile
     entries.map(&:name)
   end
 
-private
+  def load(filename)
+    entries.clear
+    parse_procfile(filename)
+  end
+
+  def write(filename)
+    File.open(filename, 'w') do |io|
+      entries.each do |ent|
+        io.puts(ent)
+      end
+    end
+  end
+
+  def <<(entry)
+    entries << Foreman::ProcfileEntry.new(*entry)
+    self
+  end
+
+
+protected
 
   def parse_procfile(filename)
     File.read(filename).split("\n").map do |line|
       if line =~ /^([A-Za-z0-9_]+):\s*(.+)$/
-        Foreman::ProcfileEntry.new($1, $2)
+        self << [ $1, $2 ]
       end
     end.compact
   end

--- a/lib/foreman/procfile_entry.rb
+++ b/lib/foreman/procfile_entry.rb
@@ -19,4 +19,8 @@ class Foreman::ProcfileEntry
     end
   end
 
+  def to_s
+    "#{name}: #{command}"
+  end
+
 end

--- a/spec/foreman/procfile_entry_spec.rb
+++ b/spec/foreman/procfile_entry_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+require 'foreman/procfile_entry'
+require 'pathname'
+require 'tmpdir'
+
+describe Foreman::ProcfileEntry do
+  subject { described_class.new('alpha', './alpha') }
+
+  it "stringifies as a Procfile line" do
+    subject.to_s.should == 'alpha: ./alpha'
+  end
+
+end

--- a/spec/foreman/procfile_spec.rb
+++ b/spec/foreman/procfile_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+require 'foreman/procfile'
+require 'pathname'
+require 'tmpdir'
+
+describe Foreman::Procfile do
+  subject { described_class.new }
+
+  let(:testdir) { Pathname(Dir.tmpdir) }
+  let(:procfile) { testdir + 'Procfile' }
+
+  it "can have a process appended to it" do
+    subject << ['alpha', './alpha']
+    subject['alpha'].should be_a(Foreman::ProcfileEntry)
+  end
+
+  it "can write itself out to a file" do
+    subject << ['alpha', './alpha']
+    subject.write(procfile)
+    procfile.read.should == "alpha: ./alpha\n"
+  end
+
+  it "can re-read entries from a file" do
+    procfile.open('w') { |io| io.puts "gamma: ./radiation", "theta: ./rate" }
+    subject << ['alpha', './alpha']
+    subject.load(procfile)
+    subject.process_names.should have(2).members
+    subject.process_names.should include('gamma', 'theta')
+  end
+
+end


### PR DESCRIPTION
This patch changes Foreman::Procfile and Foreman::ProcfileEntry so that Procfiles can be written and re-read, and also adds an append API to Foreman::Procfile to facilitate adding process entries to an object in memory.

It also adds specs for both of the modified classes.

I would make use of this API to create Procfiles programmatically and write them out as files.

Thanks for considering this request.
