### PR TITLE
Add stop_grace_time to bluepill config

### DIFF
--- a/data/export/bluepill/master.pill.erb
+++ b/data/export/bluepill/master.pill.erb
@@ -13,6 +13,7 @@ Bluepill.application("<%= app %>", :foreground => false, :log_file => "/var/log/
     process.daemonize = true
     process.environment = {"PORT" => "<%= port %>"}
     process.stop_signals = [:quit, 30.seconds, :term, 5.seconds, :kill]
+    process.stop_grace_time = 45.seconds
 
     process.stdout = process.stderr = "<%= log_root %>/<%= app %>-<%= process.name %>-<%=num%>.log"
 


### PR DESCRIPTION
When running bluepill load with the config file generated by foreman I have been getting this error:
Config Error: Stop_grace_time should be greater than the sum of stop_signals delays!

Adding stop_grace_time fixes this.
