### PR TITLE
Add stop_grace_time to bluepill config

### DIFF
--- a/data/export/bluepill/master.pill.erb
+++ b/data/export/bluepill/master.pill.erb
@@ -13,6 +13,7 @@ Bluepill.application("<%= app %>", :foreground => false, :log_file => "/var/log/
     process.daemonize = true
     process.environment = {"PORT" => "<%= port %>"}
     process.stop_signals = [:quit, 30.seconds, :term, 5.seconds, :kill]
+    process.stop_grace_time = 45.seconds
 
     process.stdout = process.stderr = "<%= log_root %>/<%= app %>-<%= process.name %>-<%=num%>.log"
 

--- a/spec/resources/export/bluepill/app-concurrency.pill
+++ b/spec/resources/export/bluepill/app-concurrency.pill
@@ -13,6 +13,7 @@ Bluepill.application("app", :foreground => false, :log_file => "/var/log/bluepil
     process.daemonize = true
     process.environment = {"PORT" => "5000"}
     process.stop_signals = [:quit, 30.seconds, :term, 5.seconds, :kill]
+    process.stop_grace_time = 45.seconds
 
     process.stdout = process.stderr = "/var/log/app/app-alpha-1.log"
 
@@ -31,6 +32,7 @@ Bluepill.application("app", :foreground => false, :log_file => "/var/log/bluepil
     process.daemonize = true
     process.environment = {"PORT" => "5001"}
     process.stop_signals = [:quit, 30.seconds, :term, 5.seconds, :kill]
+    process.stop_grace_time = 45.seconds
 
     process.stdout = process.stderr = "/var/log/app/app-alpha-2.log"
 

--- a/spec/resources/export/bluepill/app.pill
+++ b/spec/resources/export/bluepill/app.pill
@@ -13,6 +13,7 @@ Bluepill.application("app", :foreground => false, :log_file => "/var/log/bluepil
     process.daemonize = true
     process.environment = {"PORT" => "5000"}
     process.stop_signals = [:quit, 30.seconds, :term, 5.seconds, :kill]
+    process.stop_grace_time = 45.seconds
 
     process.stdout = process.stderr = "/var/log/app/app-alpha-1.log"
 
@@ -30,6 +31,7 @@ Bluepill.application("app", :foreground => false, :log_file => "/var/log/bluepil
     process.daemonize = true
     process.environment = {"PORT" => "5100"}
     process.stop_signals = [:quit, 30.seconds, :term, 5.seconds, :kill]
+    process.stop_grace_time = 45.seconds
 
     process.stdout = process.stderr = "/var/log/app/app-bravo-1.log"
 


### PR DESCRIPTION
Added stop_grace time to bluepill config.

This should fix the following error:
Config Error: Stop_grace_time should be greater than the sum of stop_signals delays!

Also changed bluepill spec example files to include stop_grace_time
