### PR TITLE
Terminate gracefully upon SIGHUP 

### DIFF
--- a/lib/foreman/engine.rb
+++ b/lib/foreman/engine.rb
@@ -36,6 +36,7 @@ class Foreman::Engine
 
     trap("TERM") { puts "SIGTERM received"; terminate_gracefully }
     trap("INT")  { puts "SIGINT received";  terminate_gracefully }
+    trap("HUP")  { puts "SIGHUP received";  terminate_gracefully }
 
     assign_colors
     spawn_processes


### PR DESCRIPTION
Tmux sends SIGHUP when a session is killed which can result in orphaned processes. Adding a SIGHUP handler terminates the processes as expected.
