### PR TITLE
Added support for ENV variable interpolation

### DIFF
--- a/lib/foreman/engine.rb
+++ b/lib/foreman/engine.rb
@@ -50,7 +50,7 @@ class Foreman::Engine
   end
 
   def apply_environment!
-    environment.each { |k,v| ENV[k] = v.gsub(/\$([A-Za-z_0-9]+)/){ ENV[$1] } }
+    environment.each { |k,v| ENV[k] = v.gsub(/(?<!\\)\$([A-Za-z_0-9]+)/){ ENV[$1] } }
   end
 
   def self.read_environment(filename)

--- a/spec/foreman/cli_spec.rb
+++ b/spec/foreman/cli_spec.rb
@@ -161,15 +161,17 @@ describe "Foreman::CLI", :fakefs do
         end
 
         it "should handle variables" do
-          write_env('.env', 'FOO' => 'bar', 'BAR' => "qux", 'FOOBAR' => "$FOO-$BAR", 'PATH' => 'my/path:$PATH')
+          write_env('.env', 'FOO' => 'bar', 'BAR' => "qux", 'FOOBAR' => "$FOO-$BAR", 'PATH' => 'my/path:$PATH', 'MARS' => 'bars:\$PATH')
           orig_path = ENV['PATH']
 
           preserving_env do
             subject.run *command
             ENV["FOOBAR"].should == "bar-qux"
+            ENV["MARS"].should == 'bars:\$PATH'
             ENV["PATH"].should == "my/path:#{orig_path}"
           end
 
+          ENV["MARS"].should be_nil
           ENV["FOOBAR"].should be_nil
           ENV["PATH"].should == orig_path
         end


### PR DESCRIPTION
Sometimes in a .env file you just want to do something like this:

```
REDIS_PORT=7080
REDIS_URL=redis://myhost.com:$REDIS_PORT
PATH=/my/bins:$PATH
```

This commit adds support for ENV variable interpolation while running the cli for Foreman.
