### PR TITLE
fixed using YAML

### DIFF
--- a/lib/foreman/cli.rb
+++ b/lib/foreman/cli.rb
@@ -4,6 +4,7 @@ require "foreman/engine"
 require "foreman/engine/cli"
 require "foreman/export"
 require "shellwords"
+require "yaml"
 require "thor"
 
 class Foreman::CLI < Thor
@@ -126,7 +127,7 @@ private ######################################################################
   def options
     original_options = super
     return original_options unless File.exists?(".foreman")
-    defaults = YAML::load_file(".foreman") || {}
+    defaults = ::YAML::load_file(".foreman") || {}
     Thor::CoreExt::HashWithIndifferentAccess.new(defaults.merge(original_options))
   end
 


### PR DESCRIPTION
Without this, I'm getting: 

```

/home/wojtek/.rvm/gems/ruby-1.9.3-p194@tiramizoo/gems/foreman-0.48.0.pre1/lib/foreman/cli.rb:129:in `options': uninitialized constant Foreman::CLI::YAML (NameError)
    from /home/wojtek/.rvm/gems/ruby-1.9.3-p194@tiramizoo/gems/foreman-0.48.0.pre1/lib/foreman/cli.rb:108:in `load_environment!'
    from /home/wojtek/.rvm/gems/ruby-1.9.3-p194@tiramizoo/gems/foreman-0.48.0.pre1/lib/foreman/cli.rb:72:in `run'
    from /home/wojtek/.rvm/gems/ruby-1.9.3-p194@tiramizoo/gems/thor-0.15.2/lib/thor/task.rb:27:in `run'
    from /home/wojtek/.rvm/gems/ruby-1.9.3-p194@tiramizoo/gems/thor-0.15.2/lib/thor/invocation.rb:120:in `invoke_task'
    from /home/wojtek/.rvm/gems/ruby-1.9.3-p194@tiramizoo/gems/thor-0.15.2/lib/thor.rb:275:in `dispatch'
    from /home/wojtek/.rvm/gems/ruby-1.9.3-p194@tiramizoo/gems/thor-0.15.2/lib/thor/base.rb:408:in `start'
    from /home/wojtek/.rvm/gems/ruby-1.9.3-p194@tiramizoo/gems/foreman-0.48.0.pre1/bin/foreman:7:in `<top (required)>'
    from /home/wojtek/.rvm/gems/ruby-1.9.3-p194@tiramizoo/bin/foreman:19:in `load'
    from /home/wojtek/.rvm/gems/ruby-1.9.3-p194@tiramizoo/bin/foreman:19:in `<main>'
```
