### PR TITLE
Avoid crash by verifying the existence of SIGHUP before accessing it.

### DIFF
--- a/lib/foreman/engine.rb
+++ b/lib/foreman/engine.rb
@@ -39,7 +39,7 @@ class Foreman::Engine
   def start
     trap("TERM") { puts "SIGTERM received"; terminate_gracefully }
     trap("INT")  { puts "SIGINT received";  terminate_gracefully }
-    trap("HUP")  { puts "SIGHUP received";  terminate_gracefully }
+    trap("HUP")  { puts "SIGHUP received";  terminate_gracefully } if ::Signal.list.keys.include? 'HUP'
 
     startup
     spawn_processes


### PR DESCRIPTION
See also my [comment](https://github.com/ddollar/foreman/issues/216#issuecomment-6833546) in issue 216.

Issue 216 occurred due to pull request [201](https://github.com/ddollar/foreman/pull/201/files) being accepted without sufficient test support.

Not that I'm supplying a test either ;-/

Testing this might depend on the way Ruby was installed on Windows. On bare Windows, SIGHUP does not exist. But in cygwin, and (I think) mingw e.g. Git-bash, SIGHUP does exist. So, all the available ways to run Ruby on Windows should be tested—I suspect some were not!

Obviously, BTW, it's best directly to detect the presence of the feature in the local Ruby interpreter (the existence of SIGHUP) rather than detect the O/S version.
