### PR TITLE
CLI: fix directory option

### DIFF
--- a/lib/foreman/cli.rb
+++ b/lib/foreman/cli.rb
@@ -125,7 +125,7 @@ private ######################################################################
   def procfile
     case
       when options[:procfile] then options[:procfile]
-      when options[:root]     then File.expand_path(File.join(options[:app_root], "Procfile"))
+      when options[:root]     then File.expand_path(File.join(options[:root], "Procfile"))
       else "Procfile"
     end
   end


### PR DESCRIPTION
Hi guys,

Was trying to use the --directory option with foreman export and got the following issue:

```
# foreman export upstart /etc/init -a myapp -d /apps/myapp/current/
/usr/local/rvm/gems/ruby-1.9.2-head/gems/foreman-0.51.0/lib/foreman/cli.rb:128:in 'join': can't convert nil into String (TypeError)
from /usr/local/rvm/gems/ruby-1.9.2-head/gems/foreman-0.51.0/lib/foreman/cli.rb:128:in 'procfile'
...
```

It seems to only be a typo issue in the cli code.

``` ruby
def procfile
    case
      when options[:procfile] then options[:procfile]
      when options[:root]     then File.expand_path(File.join(options[:app_root], "Procfile"))
      else "Procfile"
    end
  end
```
