### PR TITLE
Make upstart export start/stop with network

### DIFF
--- a/data/export/upstart/master.conf.erb
+++ b/data/export/upstart/master.conf.erb
@@ -6,3 +6,6 @@ bash << "EOF"
 EOF
 
 end script
+
+start on started network
+stop on stopping network


### PR DESCRIPTION
The upstart export scripts don't start/stop automatically.  Would be nice if they did.  This makes them start/stop with network.
