### PR TITLE
Don't have foreman-runner depend on bash

### DIFF
--- a/bin/foreman-runner
+++ b/bin/foreman-runner
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 #
 #/ Usage: foreman-runner [-d <dir>] [-p] <command> [<args>...]
 #/
@@ -32,9 +32,9 @@ shift $((OPTIND-1))
 
 [ -z "$1" ] && usage
 
-if [ "$read_profile" == "1" ]; then
+if [ "$read_profile" = "1" ]; then
   if [ -f .profile ]; then
-    source .profile
+    . .profile
   fi
 fi
 


### PR DESCRIPTION
bash is not installed on all *nix systems, /bin/sh is.  The only bashism the script uses is shopt nullglob, but that's trivial to work around just by checking for the file with [ -f.

With these changes, foreman can be used successfully on OpenBSD and other *nix systems that don't include bash by default.
