### PR TITLE
start on boot worked with network-interface but not network

### DIFF
--- a/data/export/upstart/master.conf.erb
+++ b/data/export/upstart/master.conf.erb
@@ -7,5 +7,10 @@ EOF
 
 end script
 
-start on started network-interface
-stop on stopping network-interface
+start on (started network-interface
+          or started network-manager
+          or started networking)
+
+stop on (stopping network-interface
+         or stopping network-manager
+         or stopping networking) 

--- a/spec/resources/export/upstart/app.conf
+++ b/spec/resources/export/upstart/app.conf
@@ -7,5 +7,10 @@ EOF
 
 end script
 
-start on started network-interface
-stop on stopping network-interface
+start on (started network-interface
+          or started network-manager
+          or started networking)
+
+stop on (stopping network-interface
+         or stopping network-manager
+         or stopping networking)


### PR DESCRIPTION
Was excited to see the new start on boot stanza added to the foreman master config file. However for me on Ubuntu 12.04 my Rails app only got started when i had 
`start on started network-interface` in the conf file.

Any `upstart` experts care to comment?
