### PR TITLE
Handle multiline strings in .env file

### DIFF
--- a/lib/foreman/env.rb
+++ b/lib/foreman/env.rb
@@ -9,8 +9,10 @@ class Foreman::Env
       if line =~ /\A([A-Za-z_0-9]+)=(.*)\z/
         key = $1
         case val = $2
+          # Remove single quotes
           when /\A'(.*)'\z/ then ax[key] = $1
-          when /\A"(.*)"\z/ then ax[key] = $1.gsub(/\\(.)/, '\1')
+          # Remove double quotes and unescape string preserving newline characters
+          when /\A"(.*)"\z/ then ax[key] = $1.gsub('\n', "\n").gsub(/\\(.)/, '\1')
           else ax[key] = val
         end
       end

--- a/spec/foreman/engine_spec.rb
+++ b/spec/foreman/engine_spec.rb
@@ -90,6 +90,14 @@ describe "Foreman::Engine", :fakefs do
       subject.env["OTHER"].should == 'escaped"quote'
     end
 
+    it "should handle multiline strings" do
+      File.open("/tmp/env", "w") do |f|
+        f.puts 'FOO="bar\nbaz"'
+      end
+      subject.load_env "/tmp/env"
+      subject.env["FOO"].should == "bar\nbaz"
+    end
+
     it "should fail if specified and doesnt exist" do
       lambda { subject.load_env "/tmp/env" }.should raise_error(Errno::ENOENT)
     end


### PR DESCRIPTION
This adds support for multiline strings in format: `FOO="bar\nbaz"`. This way it's possible to use multiline strings (e.g. certificates) locally and e.g. on Heroku:

```
heroku config:add FOO="bar
baz"
```

or from a file:

cert.pem

```
bar
baz
```

```
heroku config:add FOO="`cat cert.pem`"
```
