### PR TITLE
Set $APP_ROOT instead of $HOME

### DIFF
--- a/lib/foreman/engine.rb
+++ b/lib/foreman/engine.rb
@@ -257,7 +257,7 @@ private
         reader, writer = create_pipe
         begin
           pid = process.run(:output => writer, :env => {
-            "HOME" => process.cwd,
+            "APP_ROOT" => process.cwd,
             "PORT" => port_for(process, n).to_s
           })
           writer.puts "started with pid #{pid}"


### PR DESCRIPTION
Foreman shouldn't clobber $HOME, because there would no longer a simple way to programmatically determine the user's home directory.

Closes #238
