### PR TITLE
foreman run should exit with the same code as its command

### DIFF
--- a/lib/foreman/cli.rb
+++ b/lib/foreman/cli.rb
@@ -86,6 +86,7 @@ class Foreman::CLI < Thor
       end
     end
     Process.wait(pid)
+    exit $?.exitstatus
   end
 
   desc "version", "Display Foreman gem version"

--- a/spec/foreman/cli_spec.rb
+++ b/spec/foreman/cli_spec.rb
@@ -72,6 +72,11 @@ describe "Foreman::CLI", :fakefs do
     it "includes the environment" do
       forked_foreman("run #{resource_path("bin/env FOO")} -e #{resource_path(".env")}").should == "bar\n"
     end
+
+    it "exits with the same exit code as the command" do
+      fork_and_get_exitstatus("run echo 1").should == 0
+      fork_and_get_exitstatus("run date 'invalid_date'").should == 1
+    end
   end
 
   describe "version" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -58,6 +58,12 @@ def fork_and_capture(&blk)
   end
 end
 
+def fork_and_get_exitstatus(args)
+  pid = Process.spawn("bundle exec bin/foreman #{args}", :out => "/dev/null", :err => "/dev/null")
+  Process.wait(pid)
+  $?.exitstatus
+end
+
 def mock_exit(&block)
   block.should raise_error(SystemExit)
 end


### PR DESCRIPTION
I'm using foreman to run my test suite, calling `foreman run <my tests>`. When a test fails, my test runner exits with a non-zero status code. My CI server should catch this and mark it as failed, but `foreman run` always exits with a status code of 0. So my tests look like they're passing when they fail.

This tiny patch causes `foreman run` to exit with the same status code as its command.
