### PR TITLE
Upstart pidfile generation

### DIFF
--- a/data/export/upstart/process.conf.erb
+++ b/data/export/upstart/process.conf.erb
@@ -3,3 +3,12 @@ stop on stopping <%= app %>-<%= name %>
 respawn
 
 exec su - <%= user %> -c 'cd <%= engine.root %>; export PORT=<%= port %>;<% engine.env.each_pair do |var,env| %> export <%= var.upcase %>=<%= shell_quote(env) %>; <% end %> <%= process.command %> >> <%= log %>/<%=name%>-<%=num%>.log 2>&1'
+
+post-start script
+  PID=`status <%= app %>-<%= name %> | egrep -oi '([0-9]+)$' | head -n1`
+  echo $PID > /var/run/<%= app %>-<%= name %>.pid
+end script
+
+post-stop script
+  rm -f /var/run/<%= app %>-<%= name %>.pid
+end script


### PR DESCRIPTION
Hack that generates a pifile to to /var/run  providing a standard way for others tools like monit to check processs status.
- It fits right in with the current exec
- Command and grep is an essential package comming preinstalled in all ubuntu machines, so its safe to use it.
- Does not require any more variable setting.
