### PR TITLE
foreman run can run things from the Procfile like heroku run.

### DIFF
--- a/lib/foreman/cli.rb
+++ b/lib/foreman/cli.rb
@@ -75,10 +75,19 @@ class Foreman::CLI < Thor
 
   def run(*args)
     load_environment!
+
+    if File.exist?(procfile)
+      engine.load_procfile(procfile)
+    end
+
     pid = fork do
       begin
         engine.env.each { |k,v| ENV[k] = v }
-        exec args.shelljoin
+        if args.size == 1 && process = engine.process(args.first)
+          process.exec(:env => engine.env)
+        else
+          exec args.shelljoin
+        end
       rescue Errno::EACCES
         error "not executable: #{args.first}"
       rescue Errno::ENOENT

--- a/spec/foreman/cli_spec.rb
+++ b/spec/foreman/cli_spec.rb
@@ -73,6 +73,10 @@ describe "Foreman::CLI", :fakefs do
       forked_foreman("run #{resource_path("bin/env FOO")} -e #{resource_path(".env")}").should == "bar\n"
     end
 
+    it "can run a command from the Procfile" do
+      forked_foreman("run -f #{resource_path("Procfile")} test").should == "testing\n"
+    end
+
     it "exits with the same exit code as the command" do
       fork_and_get_exitstatus("run echo 1").should == 0
       fork_and_get_exitstatus("run date 'invalid_date'").should == 1


### PR DESCRIPTION
This lets things like `foreman run console` work when `console` is a command defined in the `Procfile`.
