### PR TITLE
shared_path is set in documentation leading to early evaluation

### DIFF
--- a/lib/foreman/capistrano.rb
+++ b/lib/foreman/capistrano.rb
@@ -12,7 +12,7 @@ if defined?(Capistrano)
         set :foreman_procfile,    "Procfile"
         set :foreman_app,         application
         set :foreman_user,        user
-        set :foreman_log,         "#{shared_path}/log"
+        set :foreman_log,         'shared_path/log'
         set :foreman_concurrency, false
       DESC
       task :export, :roles => :app do


### PR DESCRIPTION
Seems like the task documentation evaluates shared_path variable a bit too early which breaks shared_path used elsewhere in deploy process. 

Specifically, for me I use the multistage capistrano extension and shared_path gets set without taking stage into consideration.
