### PR TITLE
Use runlevels in upstart config so app starts after boot in Ubuntu 12.03

### DIFF
--- a/data/export/upstart/master.conf.erb
+++ b/data/export/upstart/master.conf.erb
@@ -7,10 +7,6 @@ EOF
 
 end script
 
-start on (started network-interface
-          or started network-manager
-          or started networking)
+start on runlevel [2345]
 
-stop on (stopping network-interface
-         or stopping network-manager
-         or stopping networking)
+stop on runlevel [016]


### PR DESCRIPTION
This fixes an issue (#263) that causes apps to not start after boot in Ubuntu 12.04
