### PR TITLE
Create pidfile /var/run for upstart scripts

### DIFF
--- a/data/export/upstart/process.conf.erb
+++ b/data/export/upstart/process.conf.erb
@@ -2,4 +2,4 @@ start on starting <%= app %>-<%= name %>
 stop on stopping <%= app %>-<%= name %>
 respawn
 
-exec su - <%= user %> -c 'cd <%= engine.root %>; export PORT=<%= port %>;<% engine.env.each_pair do |var,env| %> export <%= var.upcase %>=<%= shell_quote(env) %>; <% end %> <%= process.command %> >> <%= log %>/<%=name%>-<%=num%>.log 2>&1'
+exec su - <%= user %> -c 'echo $$ > /var/run/<%=name%>-<%=num%>.pid; cd <%= engine.root %>; export PORT=<%= port %>;<% engine.env.each_pair do |var,env| %> export <%= var.upcase %>=<%= shell_quote(env) %>; <% end %> <%= process.command %> >> <%= log %>/<%=name%>-<%=num%>.log 2>&1'


### PR DESCRIPTION
I've added a line to the upstart template which stores the pid of the process created to /var/run/<%=name%>-<%=num%>.pid. This makes it more viable to monitor the upstart scripts created with a tool like Monit.
