### PR TITLE
Fix for fix on issue #260

### DIFF
--- a/lib/foreman/engine.rb
+++ b/lib/foreman/engine.rb
@@ -273,7 +273,8 @@ private
     Thread.new do
       begin
         loop do
-          (IO.select(@readers.values, nil, nil, 30).first || []).each do |reader|
+          io = IO.select(@readers.values, nil, nil, 30)
+          (io.nil? ? [] : io.first).each do |reader|
             data = reader.gets
             output_with_mutex name_for(@readers.invert[reader]), data
           end


### PR DESCRIPTION
I was getting errors for calling first on nil when timeout occurred:

```
undefined method `first' for nil:NilClass
/Users/silvio/temp1/foreman/lib/foreman/engine.rb:276:in `block (2 levels) in watch_for_output'
```
