### PR TITLE
Add timeout switch to CLI - fixes #178

### DIFF
--- a/lib/foreman/cli.rb
+++ b/lib/foreman/cli.rb
@@ -23,6 +23,7 @@ class Foreman::CLI < Thor
   method_option :env,       :type => :string,  :aliases => "-e", :desc => "Specify an environment file to load, defaults to .env"
   method_option :formation, :type => :string,  :aliases => "-m", :banner => '"alpha=5,bar=3"'
   method_option :port,      :type => :numeric, :aliases => "-p"
+  method_option :timeout,   :type => :numeric, :aliases => "-t", :desc => "Specify the amount of time (in seconds) processes have to shudown gracefully before receiving a SIGKILL, defaults to 5."
 
   class << self
     # Hackery. Take the run method away from Thor so that we can redefine it.

--- a/lib/foreman/engine.rb
+++ b/lib/foreman/engine.rb
@@ -25,6 +25,7 @@ class Foreman::Engine
     @options = options.dup
 
     @options[:formation] ||= (options[:concurrency] || "all=1")
+    @options[:timeout] ||= 5
 
     @env       = {}
     @mutex     = Mutex.new
@@ -305,7 +306,7 @@ private
       system  "sending SIGTERM to all processes"
       killall "SIGTERM"
     end
-    Timeout.timeout(5) do
+    Timeout.timeout(options[:timeout]) do
       watch_for_termination while @running.length > 0
     end
   rescue Timeout::Error


### PR DESCRIPTION
I had no idea if this should also be on the export command.
Also, because the terminate behaviour was not tested, no tests for this.
