### PR TITLE
Fix --directory option: its actually --root

### DIFF
--- a/man/foreman.1
+++ b/man/foreman.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "FOREMAN" "1" "October 2012" "Foreman 0.60.2" "Foreman Manual"
+.TH "FOREMAN" "1" "October 2012" "" ""
 .
 .SH "NAME"
 \fBforeman\fR \- manage Procfile\-based applications
@@ -90,7 +90,7 @@ Specify the user the application should be run as\. Defaults to the app name
 These options control all modes of foreman\'s operation\.
 .
 .TP
-\fB\-d\fR, \fB\-\-directory\fR
+\fB\-d\fR, \fB\-\-root\fR
 Specify an alternate application root\. This defaults to the directory containing the Procfile\.
 .
 .TP

--- a/man/foreman.1.ronn
+++ b/man/foreman.1.ronn
@@ -84,7 +84,7 @@ The following options control how the application is run:
 
 These options control all modes of foreman's operation.
 
-  * `-d`, `--directory`:
+  * `-d`, `--root`:
     Specify an alternate application root. This defaults to the directory
     containing the Procfile.
 


### PR DESCRIPTION
I was wondering why the heck passing --directory was causing nothing to happen with foreman start: I think it was interpreting it as a non-existant process name or something? foreman start --directory=some_dir was just returning without producing any output. That's probably also a bug, but I didn't bother to debug it.
