### PR TITLE
Strip Windows Line Endings

### DIFF
--- a/lib/foreman/env.rb
+++ b/lib/foreman/env.rb
@@ -5,7 +5,7 @@ class Foreman::Env
   attr_reader :entries
 
   def initialize(filename)
-    @entries = File.read(filename).split("\n").inject({}) do |ax, line|
+    @entries = File.read(filename).gsub("\r\n","\n").split("\n").inject({}) do |ax, line|
       if line =~ /\A([A-Za-z_0-9]+)=(.*)\z/
         key = $1
         case val = $2

--- a/lib/foreman/procfile.rb
+++ b/lib/foreman/procfile.rb
@@ -82,7 +82,7 @@ class Foreman::Procfile
 private
 
   def parse(filename)
-    File.read(filename).split("\n").map do |line|
+    File.read(filename).gsub("\r\n","\n").split("\n").map do |line|
       if line =~ /^([A-Za-z0-9_]+):\s*(.+)$/
         [$1, $2]
       end


### PR DESCRIPTION
In know, foreman does not support windows. However we are using vagrant to host (windows) VM machines and mounting a shared source directory on the guest (linux). For various reason, we prefer that git use windows line endings instead of unix line endings. When you checkout a repo from a windows host and mount it on a linux machine, foreman fails to properly parse arguments in that \r is included as a argument event though it should be ignored. This causes foreman start to fail.
