### PR TITLE
Remove explicit requirement on rubygems.

### DIFF
--- a/lib/foreman/process.rb
+++ b/lib/foreman/process.rb
@@ -1,5 +1,4 @@
 require "foreman"
-require "rubygems"
 
 class Foreman::Process
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,3 @@
-require "rubygems"
-
 require "simplecov"
 SimpleCov.start do
   add_filter "/spec/"


### PR DESCRIPTION
It's better to not force the use of a package manager. Better to add it
to the global RUBYOPT if needed. Also, this fixes a dependency issue
when using the .deb package (rubygems1.9.1 is not required, and should
not be).
