### PR TITLE
Make jruby in 1.9 mode work as a normal ruby

### DIFF
--- a/lib/foreman.rb
+++ b/lib/foreman.rb
@@ -9,7 +9,7 @@ module Foreman
   end
 
   def self.jruby?
-    defined?(RUBY_PLATFORM) and RUBY_PLATFORM == "java"
+    defined?(RUBY_PLATFORM) and RUBY_PLATFORM == "java" and RUBY_VERSION =~ /^1\.8\.\d+/
   end
 
   def self.ruby_18?


### PR DESCRIPTION
This is to make spawning processes work for jruby 1.7+

Note: Process.spawn does not yet support the writers on jruby, so you
will get warnings about :out and :err and you won't get the output.
That should be fixed in future versions. This will get things working
for now though.
