### PR TITLE
JRuby 1.9 doesn't require posix/spawn

### DIFF
--- a/lib/foreman.rb
+++ b/lib/foreman.rb
@@ -8,8 +8,8 @@ module Foreman
     File.expand_path("../../bin/foreman-runner", __FILE__)
   end
 
-  def self.jruby?
-    defined?(RUBY_PLATFORM) and RUBY_PLATFORM == "java"
+  def self.jruby_18?
+    defined?(RUBY_PLATFORM) and RUBY_PLATFORM == "java" and ruby_18?
   end
 
   def self.ruby_18?

--- a/lib/foreman/process.rb
+++ b/lib/foreman/process.rb
@@ -53,7 +53,7 @@ class Foreman::Process
       Dir.chdir(cwd) do
         Process.spawn env, expanded_command(env), :out => output, :err => output
       end
-    elsif Foreman.jruby?
+    elsif Foreman.jruby_18?
       require "posix/spawn"
       wrapped_command = "#{Foreman.runner} -d '#{cwd}' -p -- #{command}"
       POSIX::Spawn.spawn env, wrapped_command, :out => output, :err => output


### PR DESCRIPTION
Since JRuby 1.9 doesn't require posix/spawn, only follow that path if JRuby is loaded and running in 1.8 mode.

This is very close to the solution proposed by @danielfarrell in [#290](https://github.com/ddollar/foreman/pull/290), but follows the original spirit a little more closely.

I can also confirm that both solutions work for me, running foreman in JRuby 1.7 on Java 7.
