### PR TITLE
Add license to gemspec

### DIFF
--- a/foreman.gemspec
+++ b/foreman.gemspec
@@ -3,6 +3,7 @@ require "foreman/version"
 
 Gem::Specification.new do |gem|
   gem.name     = "foreman"
+  gem.license  = "MIT"
   gem.version  = Foreman::VERSION
 
   gem.author   = "David Dollar"


### PR DESCRIPTION
I have been collecting a list of licenses for a project I'm working on using [LicenceFinder](https://github.com/pivotal/LicenseFinder) and I noticed that foreman doesn't include a license in it's gemspec. This is a small change which adds that in.
