### PR TITLE
Don't ignore blank lines in the output

### DIFF
--- a/lib/foreman/engine/cli.rb
+++ b/lib/foreman/engine/cli.rb
@@ -54,7 +54,7 @@ class Foreman::Engine::CLI < Foreman::Engine
   end
 
   def output(name, data)
-    data.to_s.chomp.split("\n").each do |message|
+    data.to_s.lines.map(&:chomp).each do |message|
       output  = ""
       output += $stdout.color(@colors[name.split(".").first].to_sym)
       output += "#{Time.now.strftime("%H:%M:%S")} #{pad_process_name(name)} | "


### PR DESCRIPTION
This fixes the stdout code to ensure that empty lines are outputted by foreman.
Many times, these blank lines are intentional, so foreman should not
suppress them.

This fixes #286
