### PR TITLE
Ensure foreman is the process group leader

### DIFF
--- a/lib/foreman/engine.rb
+++ b/lib/foreman/engine.rb
@@ -37,6 +37,9 @@ class Foreman::Engine
   # Start the processes registered to this +Engine+
   #
   def start
+    # Make sure foreman is the process group leader.
+    Process.setpgrp unless Foreman.windows?
+
     trap("TERM") { puts "SIGTERM received"; terminate_gracefully }
     trap("INT")  { puts "SIGINT received";  terminate_gracefully }
     trap("HUP")  { puts "SIGHUP received";  terminate_gracefully } if ::Signal.list.keys.include? 'HUP'
@@ -109,7 +112,7 @@ class Foreman::Engine
       end
     else
       begin
-        Process.kill "-#{signal}", Process.pid
+        Process.kill "-#{signal}", Process.getpgrp
       rescue Errno::ESRCH, Errno::EPERM
       end
     end


### PR DESCRIPTION
Foreman should be the process leader before killing processes using
his process group id.

Before that foreman was broken when it was not spawned from a shell.

(Tested on linux only)
