### PR TITLE
Fix for high CPU load. Fixes #260 and #299.

### DIFF
--- a/lib/foreman/engine.rb
+++ b/lib/foreman/engine.rb
@@ -275,8 +275,12 @@ private
         loop do
           io = IO.select(@readers.values, nil, nil, 30)
           (io.nil? ? [] : io.first).each do |reader|
-            data = reader.gets
-            output_with_mutex name_for(@readers.invert[reader]), data
+            if reader.eof?
+              @readers.delete_if { |key, value| value == reader }
+            else
+              data = reader.gets
+              output_with_mutex name_for(@readers.invert[reader]), data
+            end
           end
         end
       rescue Exception => ex


### PR DESCRIPTION
Some processes close their output channels and IO.select keeps
returning them as "readable", while IO#gets returns nil on them, thus
spending a lot of CPU looping through the same reader continuously
