### PR TITLE
Add start-stop-daemon export support with upstart

### DIFF
--- a/data/export/daemon/master.conf.erb
+++ b/data/export/daemon/master.conf.erb
@@ -1,0 +1,14 @@
+pre-start script
+
+bash << "EOF"
+mkdir -p <%= log %>
+chown -R <%= user %> <%= log %>
+mkdir -p <%= run %>
+chown -R <%= user %> <%= run %>
+EOF
+
+end script
+
+start on runlevel [2345]
+
+stop on runlevel [016]

--- a/data/export/daemon/process.conf.erb
+++ b/data/export/daemon/process.conf.erb
@@ -1,0 +1,8 @@
+start on starting <%= app %>-<%= name.gsub('_', '-') %>
+stop on stopping <%= app %>-<%= name.gsub('_', '-') %>
+respawn
+
+env PORT=<%= port %><% engine.env.each_pair do |var, env| %>
+env <%= var.upcase %>=<%= env %><% end %>
+
+exec start-stop-daemon --start --chuid <%= user %> --chdir <%= engine.root %> --make-pidfile --pidfile <%= run %>/<%= app %>-<%= name %>-<%= num %>.pid --exec <%= executable %><%= arguments %> >> <%= log %>/<%= app %>-<%= name %>-<%= num %>.log 2>&1

--- a/data/export/daemon/process_master.conf.erb
+++ b/data/export/daemon/process_master.conf.erb
@@ -1,0 +1,2 @@
+start on starting <%= app %>
+stop on stopping <%= app %>

--- a/lib/foreman/cli.rb
+++ b/lib/foreman/cli.rb
@@ -45,6 +45,7 @@ class Foreman::CLI < Thor
 
   method_option :app,         :type => :string,  :aliases => "-a"
   method_option :log,         :type => :string,  :aliases => "-l"
+  method_option :run,         :type => :string,  :aliases => "-r", :desc => "Specify the pid file directory, defaults to /var/run/<application>"
   method_option :env,         :type => :string,  :aliases => "-e", :desc => "Specify an environment file to load, defaults to .env"
   method_option :port,        :type => :numeric, :aliases => "-p"
   method_option :user,        :type => :string,  :aliases => "-u"

--- a/lib/foreman/export.rb
+++ b/lib/foreman/export.rb
@@ -28,6 +28,7 @@ end
 require "foreman/export/base"
 require "foreman/export/inittab"
 require "foreman/export/upstart"
+require "foreman/export/daemon"
 require "foreman/export/bluepill"
 require "foreman/export/runit"
 require "foreman/export/supervisord"

--- a/lib/foreman/export/base.rb
+++ b/lib/foreman/export/base.rb
@@ -47,7 +47,9 @@ class Foreman::Export::Base
     error("Must specify a location") unless location
     FileUtils.mkdir_p(location) rescue error("Could not create: #{location}")
     FileUtils.mkdir_p(log) rescue error("Could not create: #{log}")
+    FileUtils.mkdir_p(run) rescue error("Could not create: #{run}")
     FileUtils.chown(user, nil, log) rescue error("Could not chown #{log} to #{user}")
+    FileUtils.chown(user, nil, run) rescue error("Could not chown #{run} to #{user}")
   end
 
   def app
@@ -56,6 +58,10 @@ class Foreman::Export::Base
 
   def log
     options[:log] || "/var/log/#{app}"
+  end
+
+  def run
+    options[:run] || "/var/run/#{app}"
   end
 
   def user

--- a/lib/foreman/export/daemon.rb
+++ b/lib/foreman/export/daemon.rb
@@ -1,0 +1,28 @@
+require "erb"
+require "foreman/export"
+
+class Foreman::Export::Daemon < Foreman::Export::Base
+
+  def export
+    super
+
+    (Dir["#{location}/#{app}-*.conf"] << "#{location}/#{app}.conf").each do |file|
+      clean file
+    end
+
+    write_template "daemon/master.conf.erb", "#{app}.conf", binding
+
+    engine.each_process do |name, process|
+      next if engine.formation[name] < 1
+      write_template "daemon/process_master.conf.erb", "#{app}-#{name}.conf", binding
+
+      1.upto(engine.formation[name]) do |num|
+        port = engine.port_for(process, num)
+        arguments = process.command.split(" ")
+        executable = arguments.slice!(0)
+        arguments = arguments.size > 0 ? " -- #{arguments.join(' ')}" : ""
+        write_template "daemon/process.conf.erb", "#{app}-#{name}-#{num}.conf", binding
+      end
+    end
+  end
+end

--- a/spec/foreman/export/daemon_spec.rb
+++ b/spec/foreman/export/daemon_spec.rb
@@ -1,0 +1,97 @@
+require "spec_helper"
+require "foreman/engine"
+require "foreman/export/daemon"
+require "tmpdir"
+
+describe Foreman::Export::Daemon, :fakefs do
+  let(:procfile)  { write_procfile("/tmp/app/Procfile") }
+  let(:formation) { nil }
+  let(:engine)    { Foreman::Engine.new(:formation => formation).load_procfile(procfile) }
+  let(:options)   { Hash.new }
+  let(:daemon)   { Foreman::Export::Daemon.new("/tmp/init", engine, options) }
+
+  before(:each) { load_export_templates_into_fakefs("daemon") }
+  before(:each) { stub(daemon).say }
+
+  it "exports to the filesystem" do
+    daemon.export
+
+    File.read("/tmp/init/app.conf").should         == example_export_file("daemon/app.conf")
+    File.read("/tmp/init/app-alpha.conf").should   == example_export_file("daemon/app-alpha.conf")
+    File.read("/tmp/init/app-alpha-1.conf").should == example_export_file("daemon/app-alpha-1.conf")
+    File.read("/tmp/init/app-bravo.conf").should   == example_export_file("daemon/app-bravo.conf")
+    File.read("/tmp/init/app-bravo-1.conf").should == example_export_file("daemon/app-bravo-1.conf")
+  end
+
+  it "cleans up if exporting into an existing dir" do
+    mock(FileUtils).rm("/tmp/init/app.conf")
+    mock(FileUtils).rm("/tmp/init/app-alpha.conf")
+    mock(FileUtils).rm("/tmp/init/app-alpha-1.conf")
+    mock(FileUtils).rm("/tmp/init/app-bravo.conf")
+    mock(FileUtils).rm("/tmp/init/app-bravo-1.conf")
+    mock(FileUtils).rm("/tmp/init/app-foo-bar.conf")
+    mock(FileUtils).rm("/tmp/init/app-foo-bar-1.conf")
+    mock(FileUtils).rm("/tmp/init/app-foo_bar.conf")
+    mock(FileUtils).rm("/tmp/init/app-foo_bar-1.conf")
+
+    daemon.export
+    daemon.export
+  end
+
+  it "does not delete exported files for similarly named applications" do
+    FileUtils.mkdir_p "/tmp/init"
+
+    ["app2", "app2-alpha", "app2-alpha-1"].each do |name|
+      path = "/tmp/init/#{name}.conf"
+      FileUtils.touch(path)
+      dont_allow(FileUtils).rm(path)
+    end
+
+    daemon.export
+  end
+
+  context "with a formation" do
+    let(:formation) { "alpha=2" }
+
+    it "exports to the filesystem with concurrency" do
+      daemon.export
+
+      File.read("/tmp/init/app.conf").should            == example_export_file("daemon/app.conf")
+      File.read("/tmp/init/app-alpha.conf").should      == example_export_file("daemon/app-alpha.conf")
+      File.read("/tmp/init/app-alpha-1.conf").should    == example_export_file("daemon/app-alpha-1.conf")
+      File.read("/tmp/init/app-alpha-2.conf").should    == example_export_file("daemon/app-alpha-2.conf")
+      File.exists?("/tmp/init/app-bravo-1.conf").should == false
+    end
+  end
+
+  context "with alternate templates" do
+    let(:template) { "/tmp/alternate" }
+    let(:options)  { { :app => "app", :template => template } }
+
+    before do
+      FileUtils.mkdir_p template
+      File.open("#{template}/master.conf.erb", "w") { |f| f.puts "alternate_template" }
+    end
+
+    it "can export with alternate template files" do
+      daemon.export
+      File.read("/tmp/init/app.conf").should == "alternate_template\n"
+    end
+  end
+
+  context "with alternate templates from home dir" do
+
+    before do
+      FileUtils.mkdir_p File.expand_path("~/.foreman/templates/daemon")
+      File.open(File.expand_path("~/.foreman/templates/daemon/master.conf.erb"), "w") do |file|
+        file.puts "default_alternate_template"
+      end
+    end
+
+    it "can export with alternate template files" do
+      daemon.export
+      File.read("/tmp/init/app.conf").should == "default_alternate_template\n"
+    end
+  end
+
+end

--- a/spec/resources/export/daemon/app-alpha-1.conf
+++ b/spec/resources/export/daemon/app-alpha-1.conf
@@ -1,0 +1,7 @@
+start on starting app-alpha
+stop on stopping app-alpha
+respawn
+
+env PORT=5000
+
+exec start-stop-daemon --start --chuid app --chdir /tmp/app --make-pidfile --pidfile /var/run/app/app-alpha-1.pid --exec ./alpha >> /var/log/app/app-alpha-1.log 2>&1

--- a/spec/resources/export/daemon/app-alpha-2.conf
+++ b/spec/resources/export/daemon/app-alpha-2.conf
@@ -1,0 +1,7 @@
+start on starting app-alpha
+stop on stopping app-alpha
+respawn
+
+env PORT=5001
+
+exec start-stop-daemon --start --chuid app --chdir /tmp/app --make-pidfile --pidfile /var/run/app/app-alpha-2.pid --exec ./alpha >> /var/log/app/app-alpha-2.log 2>&1

--- a/spec/resources/export/daemon/app-alpha.conf
+++ b/spec/resources/export/daemon/app-alpha.conf
@@ -1,0 +1,2 @@
+start on starting app
+stop on stopping app

--- a/spec/resources/export/daemon/app-bravo-1.conf
+++ b/spec/resources/export/daemon/app-bravo-1.conf
@@ -1,0 +1,7 @@
+start on starting app-bravo
+stop on stopping app-bravo
+respawn
+
+env PORT=5100
+
+exec start-stop-daemon --start --chuid app --chdir /tmp/app --make-pidfile --pidfile /var/run/app/app-bravo-1.pid --exec ./bravo >> /var/log/app/app-bravo-1.log 2>&1

--- a/spec/resources/export/daemon/app-bravo.conf
+++ b/spec/resources/export/daemon/app-bravo.conf
@@ -1,0 +1,2 @@
+start on starting app
+stop on stopping app

--- a/spec/resources/export/daemon/app.conf
+++ b/spec/resources/export/daemon/app.conf
@@ -1,0 +1,14 @@
+pre-start script
+
+bash << "EOF"
+mkdir -p /var/log/app
+chown -R app /var/log/app
+mkdir -p /var/run/app
+chown -R app /var/run/app
+EOF
+
+end script
+
+start on runlevel [2345]
+
+stop on runlevel [016]


### PR DESCRIPTION
I've added a new "daemon" export type that uses start-stop-daemon in conjunction with upstart, with pidfile support.
