### PR TITLE
Add support for global .env file

### DIFF
--- a/lib/foreman/cli.rb
+++ b/lib/foreman/cli.rb
@@ -126,6 +126,7 @@ private ######################################################################
   end
 
   def load_environment!
+    load_global_environment!
     if options[:env]
       options[:env].split(",").each do |file|
         engine.load_env file
@@ -134,6 +135,11 @@ private ######################################################################
       default_env = File.join(engine.root, ".env")
       engine.load_env default_env if File.exists?(default_env)
     end
+  end
+
+  def load_global_environment!
+    global_env = File.join(ENV["HOME"], ".env")
+    engine.load_env global_env if File.exists?(global_env)
   end
 
   def procfile

--- a/spec/foreman/cli_spec.rb
+++ b/spec/foreman/cli_spec.rb
@@ -73,6 +73,13 @@ describe "Foreman::CLI", :fakefs do
       forked_foreman("run #{resource_path("bin/env FOO")} -e #{resource_path(".env")}").should == "bar\n"
     end
 
+    it "includes the default environment" do
+      pending
+      write_env("#{ENV["HOME"]}/.env", {"GLOBAL_FOO" => "GLOBAL_BAR"})
+      forked_foreman("run #{resource_path("bin/env FOO")} -e #{resource_path("#{ENV["HOME"]}/.env")}").should == "bar\n"
+      forked_foreman("run #{resource_path("bin/env FOO")} -e #{resource_path(".env")}").should == "bar\n"
+    end
+
     it "can run a command from the Procfile" do
       forked_foreman("run -f #{resource_path("Procfile")} test").should == "testing\n"
     end


### PR DESCRIPTION
The global .env file is designed to sit in your home directory and provide defaults for any env vars that you might want.  Each key is overridable within a project specific .env file.

For instance, you may set your local Postgres server credentials in your global .env and use them inside your database.yml, but want to have project specific settings for connecting to a different postgres service.

**NOTE: DO NOT MERGE THIS YET!**

There is a pending test in cli_spec which I need help with. I'm unclear on how to create a test that represents what is happening.  In true back to front fashion though, I know the code is working.  Help welcome.
