### PR TITLE
Fix color bug: not intense_cyan but bright_cyan

### DIFF
--- a/lib/foreman/engine/cli.rb
+++ b/lib/foreman/engine/cli.rb
@@ -45,7 +45,7 @@ class Foreman::Engine::CLI < Foreman::Engine
   end
 
   FOREMAN_COLORS = %w( cyan yellow green magenta red blue bright_cyan bright_yellow
-                       bright_green bright_magenta bright_red, bright_blue )
+                       bright_green bright_magenta bright_red bright_blue )
 
   def startup
     @colors = map_colors
@@ -89,7 +89,7 @@ private
     @names.values.each_with_index do |name, index|
       colors[name] = FOREMAN_COLORS[index % FOREMAN_COLORS.length]
     end
-    colors["system"] = "intense_white"
+    colors["system"] = "bright_white"
     colors
   end
 


### PR DESCRIPTION
[ANSI array](https://github.com/sonots/foreman/blob/1d2bcdbc56acd2f1d39880abf6211267bea33721/lib/foreman/engine/cli.rb#L7) is defined as below. `intense_cyan` should be `bright_cyan`. Same for others. 

```
ANSI = {
  :reset          => 0,
  :black          => 30,
  :red            => 31,
  :green          => 32,
  :yellow         => 33,
  :blue           => 34,
  :magenta        => 35,
  :cyan           => 36,
  :white          => 37,
  :bright_black   => 30,
  :bright_red     => 31,
  :bright_green   => 32,
  :bright_yellow  => 33,
  :bright_blue    => 34,
  :bright_magenta => 35,
  :bright_cyan    => 36,
  :bright_white   => 37,
}
```
