### PR TITLE
Prevent upstart export from deleting similarly named upstart files

### DIFF
--- a/lib/foreman/export/upstart.rb
+++ b/lib/foreman/export/upstart.rb
@@ -6,7 +6,7 @@ class Foreman::Export::Upstart < Foreman::Export::Base
   def export
     super
 
-    Dir["#{location}/#{app}*.conf"].each do |file|
+    (Dir["#{location}/#{app}-*.conf"] << "#{location}/#{app}.conf").each do |file|
       clean file
     end
 

--- a/spec/foreman/export/upstart_spec.rb
+++ b/spec/foreman/export/upstart_spec.rb
@@ -34,6 +34,18 @@ describe Foreman::Export::Upstart, :fakefs do
     upstart.export
   end
 
+  it "does not delete exported files for similarly named applications" do
+    FileUtils.mkdir_p "/tmp/init"
+
+    ["app2", "app2-alpha", "app2-alpha-1"].each do |name|
+      path = "/tmp/init/#{name}.conf"
+      FileUtils.touch(path)
+      dont_allow(FileUtils).rm(path)
+    end
+
+    upstart.export
+  end
+
   it "quotes and escapes environment variables" do
     engine.env['KEY'] = 'd"\|d'
     upstart.export


### PR DESCRIPTION
The upstart export deletes files named `#{app}*.conf` which may include files other than the ones previously exported. For example, exporting with an application name of `ab` deletes `abc.conf`. Here is a small fix to only delete `#{app}.conf` and `#{app}-*.conf`, thus preserving files like `#{app}2.conf`, `#{app}2-process.conf`, etc.

(Edited to clarify)
