### PR TITLE
Be more specific when cleaning upstart scripts

### DIFF
--- a/lib/foreman/export/upstart.rb
+++ b/lib/foreman/export/upstart.rb
@@ -6,7 +6,7 @@ class Foreman::Export::Upstart < Foreman::Export::Base
   def export
     super
 
-    Dir["#{location}/#{app}*.conf"].each do |file|
+    Dir["#{location}/#{app}.conf", "#{location}/#{app}-*.conf"].each do |file|
       clean file
     end
 


### PR DESCRIPTION
`sudo foreman export upstart /etc/init`

was cleaning "/etc/init/apport.conf". Oops !
