### PR TITLE
Update man/foreman.1

### DIFF
--- a/man/foreman.1
+++ b/man/foreman.1
@@ -234,7 +234,7 @@ Run one process type from the application defined in a specific Procfile:
 .
 .nf
 
-$ foreman start alpha \-p ~/myapp/Procfile
+$ foreman start alpha \-f ~/myapp/Procfile
 .
 .fi
 .


### PR DESCRIPTION
fix man example typo: Procfile flag is `-f`, not `-p`
