### PR TITLE
add change-pgrp option (default true)

### DIFF
--- a/lib/foreman/cli.rb
+++ b/lib/foreman/cli.rb
@@ -19,11 +19,12 @@ class Foreman::CLI < Thor
 
   desc "start [PROCESS]", "Start the application (or a specific PROCESS)"
 
-  method_option :color,     :type => :boolean, :aliases => "-c", :desc => "Force color to be enabled"
-  method_option :env,       :type => :string,  :aliases => "-e", :desc => "Specify an environment file to load, defaults to .env"
-  method_option :formation, :type => :string,  :aliases => "-m", :banner => '"alpha=5,bar=3"'
-  method_option :port,      :type => :numeric, :aliases => "-p"
-  method_option :timeout,   :type => :numeric, :aliases => "-t", :desc => "Specify the amount of time (in seconds) processes have to shutdown gracefully before receiving a SIGKILL, defaults to 5."
+  method_option :color,       :type => :boolean, :aliases => "-c", :desc => "Force color to be enabled"
+  method_option :env,         :type => :string,  :aliases => "-e", :desc => "Specify an environment file to load, defaults to .env"
+  method_option :formation,   :type => :string,  :aliases => "-m", :banner => '"alpha=5,bar=3"'
+  method_option :port,        :type => :numeric, :aliases => "-p"
+  method_option :timeout,     :type => :numeric, :aliases => "-t", :desc => "Specify the amount of time (in seconds) processes have to shutdown gracefully before receiving a SIGKILL, defaults to 5."
+  method_option :change_pgrp, :type => :boolean, :default => true, :desc => "Change process group explicitly. Not work with Windows"
 
   class << self
     # Hackery. Take the run method away from Thor so that we can redefine it.

--- a/lib/foreman/engine.rb
+++ b/lib/foreman/engine.rb
@@ -39,7 +39,7 @@ class Foreman::Engine
   #
   def start
     # Make sure foreman is the process group leader.
-    Process.setpgrp unless Foreman.windows?
+    Process.setpgrp if !Foreman.windows? and options[:change_pgrp]
 
     trap("TERM") { puts "SIGTERM received"; terminate_gracefully }
     trap("INT")  { puts "SIGINT received";  terminate_gracefully }


### PR DESCRIPTION
I want to use foreman in the Procfile.

```
# Procfile
foreman:   bundle exec foreman start -f Procfile.internal
```

In the child foreman process, I don't want to change its process group because the parent foreman process will send signal to the parent's process group. So I added `--change-pgrp` option. The default value is `true`. If someone wants to use foreman in Procfile, he or she can use `--no-change-pgrp` option in the Procfile.

```
# Procfile
foreman:   bundle exec foreman start -f Procfile.internal --no-change-prgp
```
