### PR TITLE
Fix spec encoding problem under Ruby 2.0.0.

### DIFF
--- a/spec/foreman/process_spec.rb
+++ b/spec/foreman/process_spec.rb
@@ -41,7 +41,7 @@ describe Foreman::Process do
 
     it "should output utf8 properly" do
       process = Foreman::Process.new(resource_path("bin/utf8"))
-      run(process).should == "\xFF\x03\n"
+      run(process).should == "\xFF\x03\n".force_encoding('binary')
     end
   end
 


### PR DESCRIPTION
This fixes the spec failure under [Ruby 2.0.0p0](https://travis-ci.org/ddollar/foreman/jobs/5232121).

It doesn't look like you're maintaining 1.8.7 compatibility (at least the travis config makes it seem that way), but if you were, you'd probably want to split the `force_encoding` call onto a line by itself with a `respond_to?` guard.
