### PR TITLE
Allow '.' in env files

### DIFF
--- a/lib/foreman/env.rb
+++ b/lib/foreman/env.rb
@@ -6,7 +6,7 @@ class Foreman::Env
 
   def initialize(filename)
     @entries = File.read(filename).gsub("\r\n","\n").split("\n").inject({}) do |ax, line|
-      if line =~ /\A([A-Za-z_0-9]+)=(.*)\z/
+      if line =~ /\A([A-Za-z_0-9\.]+)=(.*)\z/
         key = $1
         case val = $2
           # Remove single quotes


### PR DESCRIPTION
Minimal change to foreman env.rb so that dot notation is supported in property files.
