### PR TITLE
Rescue and log on Process.setpgrp exception.

### DIFF
--- a/lib/foreman/engine.rb
+++ b/lib/foreman/engine.rb
@@ -52,8 +52,12 @@ class Foreman::Engine
   # Start the processes registered to this +Engine+
   #
   def start
-    # Make sure foreman is the process group leader.
-    Process.setpgrp unless Foreman.windows?
+    begin
+      # Attempt to make foreman the process group leader.
+      Process.setpgrp unless Foreman.windows?
+    rescue Errno::EPERM
+      puts "Warning: Could not make foreman the process group leader. Continuing"
+    end
 
     register_signal_handlers
     startup


### PR DESCRIPTION
Hey,

Really excited about leveraging foreman!  I'm learning more about it, but ran into this issue.  

Right now, I'm running `foreman start` from within a systemd unit.  Since systemd is already managing the process group, foreman gets a permissions error when trying to set the process group.

I'm starting to think that I may need to actually find/write a systemd exporter, and then manage the individual processes with systemd rather than foreman (so foreman would be used exclusively for exporting).  That approach has some nice things about it, but I think my naive use-case is still a viable one.

It's a quick fix to swallow the Process.setpgrp permissions error.  Do you this this approach is valid or am I looking at it backwards and should write an exporter?  Thanks!

-Nick
