### PR TITLE
chmod: print mode in octal format (if given as a number)

### DIFF
--- a/lib/foreman/export/base.rb
+++ b/lib/foreman/export/base.rb
@@ -124,7 +124,7 @@ private ######################################################################
   end
 
   def chmod(mode, file)
-    say "setting #{file} to mode #{mode}"
+    say "setting #{file} to mode #{mode.is_a?(Fixnum) ? sprintf('%#o', mode) : mode}"
     FileUtils.chmod mode, File.join(location, file)
   end
 


### PR DESCRIPTION
In Foreman::Export::Base.chmod, the new file mode was printed as-is, which means printing an octal number in decimal format (if a number-style argument is passed to FileUtils.chmod). This changes it to octal output (unless a string mode is passed).
