### PR TITLE
Remove posix-spawn dependency for JRuby

### DIFF
--- a/foreman.gemspec
+++ b/foreman.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'thor', '>= 0.13.6'
 
   if ENV["PLATFORM"] == "java"
-    gem.add_dependency "posix-spawn", "~> 0.3.6"
     gem.platform = Gem::Platform.new("java")
   end
 


### PR DESCRIPTION
Using posix-spawn causes foreman to crash if you are using JRuby 1.7.3 if running in 1.8 mode. C extensions had previously been deprecated and are now broken in the latest JRuby version and the maintainers have [no intention of making them work](https://github.com/jruby/jruby/issues/594).
