### PR TITLE
Fix exporters and typo in manual page

### DIFF
--- a/man/foreman.1
+++ b/man/foreman.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "FOREMAN" "1" "January 2013" "Foreman 0.61.0" "Foreman Manual"
+.TH "FOREMAN" "1" "April 2013" "Foreman 0.63.0" "Foreman Manual"
 .
 .SH "NAME"
 \fBforeman\fR \- manage Procfile\-based applications
@@ -107,7 +107,13 @@ bluepill
 inittab
 .
 .IP "\(bu" 4
+launchd
+.
+.IP "\(bu" 4
 runit
+.
+.IP "\(bu" 4
+supervisord
 .
 .IP "\(bu" 4
 upstart

--- a/man/foreman.1.ronn
+++ b/man/foreman.1.ronn
@@ -101,7 +101,11 @@ foreman currently supports the following output formats:
 
   * inittab
 
+  * launchd
+
   * runit
+
+  * supervisord
 
   * upstart
 
@@ -168,7 +172,7 @@ Export the application in upstart format:
 
 Run one process type from the application defined in a specific Procfile:
 
-    $ foreman start alpha -p ~/myapp/Procfile
+    $ foreman start alpha -f ~/myapp/Procfile
 
 ## COPYRIGHT
 


### PR DESCRIPTION
- Fix available exporters list
- Fix man example typo in ronn file: Procfile flag is `-f`, not `-p`
