### PR TITLE
fix Launchd export - replace $PORT in program args

### DIFF
--- a/lib/foreman/export/launchd.rb
+++ b/lib/foreman/export/launchd.rb
@@ -8,7 +8,12 @@ class Foreman::Export::Launchd < Foreman::Export::Base
     engine.each_process do |name, process|
       1.upto(engine.formation[name]) do |num|
         port = engine.port_for(process, num)
-        command_args = process.command.split(" ")
+        command_args = process.command.split(/\s+/).map{|arg|
+          case arg
+          when "$PORT" then port
+          else arg
+          end
+        }
         write_template "launchd/launchd.plist.erb", "#{app}-#{name}-#{num}.plist", binding
       end
     end


### PR DESCRIPTION
replace $PORT with `engine.port_for(process, num)` in ProgramArguments of Launchd export.
## problem

export launchd .plist file

```
% foreman export launchd ~/Library/LaunchAgents/ --app test-app --port 6100
```

`$PORT` in ProgramArguments will not be 6100 on Launchd.
It will be string "$PORT".

``` xml
<key>EnvironmentVariables</key>
<dict>
    <key>PORT</key>
    <string>6100</string>
</dict>
<key>ProgramArguments</key>
<array>
    <string>bundle</string>
    <string>exec</string>
    <string>rackup</string>
    <string>config.ru</string>
    <string>-p</string>
    <string>$PORT</string>
</array>
```
## fix

replace $PORT with `engine.port_for(process, num)`

``` xml
<key>EnvironmentVariables</key>
<dict>
    <key>PORT</key>
    <string>6100</string>
</dict>
<key>ProgramArguments</key>
<array>
    <string>bundle</string>
    <string>exec</string>
    <string>rackup</string>
    <string>config.ru</string>
    <string>-p</string>
    <string>6100</string>
</array>
```
