### PR TITLE
Fix issue with process invocation when using dash

### DIFF
--- a/lib/foreman/process.rb
+++ b/lib/foreman/process.rb
@@ -59,7 +59,7 @@ class Foreman::Process
       wrapped_command = "#{runner} -d '#{cwd.shellescape}' -p -- #{expanded_command(env)}"
       POSIX::Spawn.spawn(*spawn_args(env, wrapped_command.shellsplit, {:out => output, :err => output}))
     else
-      wrapped_command = "#{runner} -d '#{cwd.shellescape}' -p -- #{command}"
+      wrapped_command = "exec #{runner} -d '#{cwd.shellescape}' -p -- #{command}"
       Process.spawn env, wrapped_command, :out => output, :err => output
     end
   end


### PR DESCRIPTION
Debian and ubuntu use `dash` as their system shell (/bin/sh). When dash is sent a SIGTERM, it does not kill the children processes. When foreman launches a command, it has the shell running as it's child, and then the actual command running as a child of the shell. When foreman sends a SIGTERM, it only kills the shell, and the children of the shell remain running. 

/cc @ddollar 
