### PR TITLE
Don't make log and run dirs on export

### DIFF
--- a/lib/foreman/export/base.rb
+++ b/lib/foreman/export/base.rb
@@ -46,10 +46,6 @@ class Foreman::Export::Base
   def export
     error("Must specify a location") unless location
     FileUtils.mkdir_p(location) rescue error("Could not create: #{location}")
-    FileUtils.mkdir_p(log) rescue error("Could not create: #{log}")
-    FileUtils.mkdir_p(run) rescue error("Could not create: #{run}")
-    FileUtils.chown(user, nil, log) rescue error("Could not chown #{log} to #{user}")
-    FileUtils.chown(user, nil, run) rescue error("Could not chown #{run} to #{user}")
   end
 
   def app


### PR DESCRIPTION
We've been using foreman to run our code in development. When we want to deploy we package everything up as a deb which we install on our remote servers, with upstart taking care of running processes. We'd like to use foreman to generate upstart scripts and include these in the deb package, but the export fails when foreman tries to create log and run dirs. Creating these dirs locally doesn't make sense for us as we just want to push the generated scripts to our remote servers. We don't want to have to install ruby and foreman on our production servers just to generate upstart scripts.

This patch stops foreman from trying to create those dirs on export. I figure it makes more sense to shift the responsibility for creating log and run dirs to the scripts themselves - indeed the included upstart template already creates the log dir. Feel free to reject the patch if you disagree.
