### PR TITLE
Use weak rather than strong quoting in upstart

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,8 @@
-## 0.64.0 (2013-12-11)
+## 0.63.101 (2013-12-18)
+
+* 9F: Stop shell quoting - it's unnecessary
+
+## 0.63.100 (2013-12-11)
 
 * 9F: Export environment variables outside of the running command
 

--- a/data/export/upstart/process.conf.erb
+++ b/data/export/upstart/process.conf.erb
@@ -4,7 +4,7 @@ respawn
 
 env PORT=<%= port %>
 <% engine.env.each_pair do |var,env| -%>
-env <%= var.upcase %>=<%= shell_quote(env) %>
+env <%= var.upcase %>=<%= env %>
 <% end -%>
 
 exec su <%= user %> -l -m -c 'cd <%= engine.root %>; <%= process.command %> >> <%= log %>/<%=name%>-<%=num%>.log 2>&1'

--- a/lib/foreman/version.rb
+++ b/lib/foreman/version.rb
@@ -1,5 +1,5 @@
 module Foreman
 
-  VERSION = "0.63.100"
+  VERSION = "0.63.101"
 
 end


### PR DESCRIPTION
- Strong quoting 'blah' will break the process if there is an
  environment variable with a single quote in it. This occurs
  despite escaping the quote since escaping is not interpreted
  by bash in a strongly quoted string.
- Weak quoting "blah" will correctly pass the entire string
