### PR TITLE
export: fix systemd dependencies

### DIFF
--- a/data/export/systemd/master.target.erb
+++ b/data/export/systemd/master.target.erb
@@ -1,1 +1,6 @@
 [Unit]
+StopWhenUnneeded=true
+Wants=<%= process_master_names.join(' ') %>
+
+[Install]
+WantedBy=multi-user.target

--- a/data/export/systemd/process.service.erb
+++ b/data/export/systemd/process.service.erb
@@ -13,6 +13,3 @@ StandardOutput=syslog
 StandardError=syslog
 SyslogIdentifier=%n
 KillMode=process
-
-[Install]
-WantedBy=<%= app %>-<%= name %>.target

--- a/data/export/systemd/process_master.target.erb
+++ b/data/export/systemd/process_master.target.erb
@@ -1,5 +1,3 @@
 [Unit]
 StopWhenUnneeded=true
-
-[Install]
-WantedBy=<%= app %>.target
+Wants=<%= process_names.join(' ') %>

--- a/lib/foreman/export/systemd.rb
+++ b/lib/foreman/export/systemd.rb
@@ -10,16 +10,23 @@ class Foreman::Export::Systemd < Foreman::Export::Base
       clean file
     end
 
-    write_template "systemd/master.target.erb", "#{app}.target", binding
+    process_master_names = []
 
     engine.each_process do |name, process|
       next if engine.formation[name] < 1
-      write_template "systemd/process_master.target.erb", "#{app}-#{name}.target", binding
+
+      process_names = []
 
       1.upto(engine.formation[name]) do |num|
         port = engine.port_for(process, num)
         write_template "systemd/process.service.erb", "#{app}-#{name}-#{num}.service", binding
+        process_names << "#{app}-#{name}-#{num}.service"
       end
+
+      write_template "systemd/process_master.target.erb", "#{app}-#{name}.target", binding
+      process_master_names << "#{app}-#{name}.target"
     end
+
+    write_template "systemd/master.target.erb", "#{app}.target", binding
   end
 end


### PR DESCRIPTION
With the previous way systemd services were exported, you had to enable every single process one by one to get the service operational.

Consider the following Procfile:

```
web: bundle exec thin start
worker: bundle exec worker start
```

Exported with:

```
foreman export systemd /usr/lib/systemd/system -a myapp -c all=1,worker=3
```

You will have to perform the following to start the service:

```
systemctl enable myapp-web-1.service
systemctl enable myapp-worker-1.service
systemctl enable myapp-worker-2.service
systemctl enable myapp-worker-3.service
systemctl enable myapp-web.target
systemctl enable myapp-worker.target
systemctl start myapp.target
```

Thats 7 commands, and you have to know the names of each service. Nasty.

With the changes here, you will have to perform the following:

```
systemctl start myapp.target
```

_(with the previous code, you couldn't even start `myapp.target` without first enabling everything, which may not be desired)_

And to enable it on boot:

```
systemctl enable myapp.target
```

---

Additionally, this change also adds the dependency to 'multi-user.target' (the default behavior for all services). This will properly shut down (or start) the app when the system changes runlevels. The previous method did not do this.
