### PR TITLE
specify a shell when using upstart

### DIFF
--- a/data/export/upstart/process.conf.erb
+++ b/data/export/upstart/process.conf.erb
@@ -2,4 +2,4 @@ start on starting <%= app %>-<%= name %>
 stop on stopping <%= app %>-<%= name %>
 respawn
 
-exec su - <%= user %> -s /bin/sh -c 'cd <%= engine.root %>; export PORT=<%= port %>;<% engine.env.each_pair do |var,env| %> export <%= var.upcase %>=<%= shell_quote(env) %>; <% end %> <%= process.command %> >> <%= log %>/<%=name%>-<%=num%>.log 2>&1'
+exec su - <%= user %> -s /bin/sh -c 'cd <%= engine.root %>; export PORT=<%= port %>;<% engine.env.each_pair do |var,env| %> export <%= var.upcase %>=<%= shell_quote(env) %>; <% end %> exec <%= process.command %> >> <%= log %>/<%=name%>-<%=num%>.log 2>&1'


### PR DESCRIPTION
When an upstart service is exported, the command used does not specify a shell. It instead relies upon the user to have a shell. However it is basic security practices for system accounts to not have a shell (shell set to `/bin/false`, or `/usr/sbin/nologin`, etc). This causes the upstart job to fail as the user has no shell.

This change forces the shell to `/bin/sh`.  
POSIX does not mandate that a shell exist at `/bin/sh`, however this is standard practice as the location is relied upon by may other projects. POSIX does require that a shell called `sh` be available, just not at a certain path. Instead it says the location should be discovered through `$PATH`. It would be possible to therefore find `sh` by `command -v sh`, but given the standard practice of `/bin/sh`, I deemed this added complexity as unnecessary.
