### PR TITLE
Allow setting the location of the directory containing the .foreman file

### DIFF
--- a/lib/foreman/cli.rb
+++ b/lib/foreman/cli.rb
@@ -20,6 +20,7 @@ class Foreman::CLI < Thor
   desc "start [PROCESS]", "Start the application (or a specific PROCESS)"
 
   method_option :color,     :type => :boolean, :aliases => "-c", :desc => "Force color to be enabled"
+  method_option :defaults,  :type => :string,  :aliases => "-s",  :default => "."
   method_option :env,       :type => :string,  :aliases => "-e", :desc => "Specify an environment file to load, defaults to .env"
   method_option :formation, :type => :string,  :aliases => "-m", :banner => '"alpha=5,bar=3"'
   method_option :port,      :type => :numeric, :aliases => "-p"
@@ -157,8 +158,9 @@ private ######################################################################
 
   def options
     original_options = super
-    return original_options unless File.exists?(".foreman")
-    defaults = ::YAML::load_file(".foreman") || {}
+    defaults_file = File.join(original_options[:defaults], ".foreman")
+    return original_options unless File.exists?(defaults_file)
+    defaults = ::YAML::load_file(defaults_file) || {}
     Thor::CoreExt::HashWithIndifferentAccess.new(defaults.merge(original_options))
   end
 

--- a/man/foreman.1.ronn
+++ b/man/foreman.1.ronn
@@ -40,6 +40,10 @@ The following options control how the application is run:
     Specify which port to use as the base for this application. Should be
     a multiple of 1000.
 
+  * `-s`, `--defaults`:
+    Specify the directory containing the .foreman file. Defaults to
+    the current dir.
+
 `foreman run` is used to run one-off commands using the same environment
 as your defined processes.
 

--- a/spec/foreman/cli_spec.rb
+++ b/spec/foreman/cli_spec.rb
@@ -15,6 +15,12 @@ describe "Foreman::CLI", :fakefs do
       subject = Foreman::CLI.new([], :formation => "alpha=3")
       subject.send(:options)["formation"].should == "alpha=3"
     end
+
+    it 'can be set in a different location' do
+      File.open("../.foreman", "w") { |f| f.puts "formation: alpha=4" }
+      subject = Foreman::CLI.new([], :defaults => '../')
+      subject.send(:options)["formation"].should == "alpha=4"
+    end
   end
 
   describe "start" do


### PR DESCRIPTION
Since it's possible to specify the location of every configuration file in the foreman CLI, it would be nice to be able to do the same for the configuration file containing the defaults (`.foreman`).

This pull request does just that.
