### PR TITLE
Use %Q{} to allow commands with quotes

### DIFF
--- a/data/export/bluepill/master.pill.erb
+++ b/data/export/bluepill/master.pill.erb
@@ -7,7 +7,7 @@ Bluepill.application("<%= app %>", :foreground => false, :log_file => "/var/log/
 <% 1.upto(engine.formation[name]) do |num| %>
   <% port = engine.port_for(process, num) %>
   app.process("<%= name %>-<%= num %>") do |process|
-    process.start_command = "<%= process.command %>"
+    process.start_command = %Q{<%= process.command %>}
 
     process.working_dir = "<%= engine.root %>"
     process.daemonize = true


### PR DESCRIPTION
I have this command in my Procfile: `sidekiq: bundle exec sidekiq -r "$(pwd)/app.rb"`. This generates an invalid ruby file. This commit uses %Q{} which allows for any combination of double quotes and single quotes.
