### PR TITLE
engine.kill_children needs to kill the children spawned by foreman-runner

### DIFF
--- a/lib/foreman/engine.rb
+++ b/lib/foreman/engine.rb
@@ -381,10 +381,9 @@ private
   end
 
   def watch_for_termination
-    Process.waitall.each do |(pid, status)|
-      output_with_mutex name_for(pid), termination_message_for(status)
-      @running.delete(pid)
-    end
+    pid, status = Process.wait2
+    output_with_mutex name_for(pid), termination_message_for(status)
+    @running.delete(pid)    
     yield if block_given?
   rescue Errno::ECHILD
   end


### PR DESCRIPTION
Should close #357
- Just sending kill to the foreman-runner processes is not enough and would leave
  the grandchildren up and running.
- Process.kill signal, *a stops once it hits a processes that's already gone -> replace with a plain loop
- engine.killall was not used anymore
