### PR TITLE
Export env vars from upstart prior to the exec

### DIFF
--- a/data/export/upstart/process.conf.erb
+++ b/data/export/upstart/process.conf.erb
@@ -2,4 +2,9 @@ start on starting <%= app %>-<%= name %>
 stop on stopping <%= app %>-<%= name %>
 respawn
 
-exec su - <%= user %> -c 'cd <%= engine.root %>; export PORT=<%= port %>;<% engine.env.each_pair do |var,env| %> export <%= var.upcase %>=<%= shell_quote(env) %>; <% end %> <%= process.command %> >> <%= log %>/<%=name%>-<%=num%>.log 2>&1'
+env PORT=<%= port %>
+<% engine.env.each_pair do |var,env| -%>
+env <%= var.upcase %>=<%= env %>
+<% end -%>
+
+exec su <%= user %> -l -m -c 'cd <%= engine.root %>; <%= process.command %> >> <%= log %>/<%=name%>-<%=num%>.log 2>&1'


### PR DESCRIPTION
The current upstart template exports the env vars from within the exec'd shell command.  This clutters ps output and is a potential security concern if the env vars contain sensitive credentials.

This PR pulls the exports up, into the upstart config.
