### PR TITLE
don't fork on 'run'

### DIFF
--- a/lib/foreman/cli.rb
+++ b/lib/foreman/cli.rb
@@ -83,22 +83,18 @@ class Foreman::CLI < Thor
       engine.load_procfile(procfile)
     end
 
-    pid = fork do
-      begin
-        engine.env.each { |k,v| ENV[k] = v }
-        if args.size == 1 && process = engine.process(args.first)
-          process.exec(:env => engine.env)
-        else
-          exec args.shelljoin
-        end
-      rescue Errno::EACCES
-        error "not executable: #{args.first}"
-      rescue Errno::ENOENT
-        error "command not found: #{args.first}"
+    begin
+      engine.env.each { |k,v| ENV[k] = v }
+      if args.size == 1 && process = engine.process(args.first)
+        process.exec(:env => engine.env)
+      else
+        exec args.shelljoin
       end
+    rescue Errno::EACCES
+      error "not executable: #{args.first}"
+    rescue Errno::ENOENT
+      error "command not found: #{args.first}"
     end
-    Process.wait(pid)
-    exit $?.exitstatus
   end
 
   desc "version", "Display Foreman gem version"


### PR DESCRIPTION
This removes the fork when doing `foreman run`. The fork results in an unnecessary process laying around. The parent process doesn't do anything other than fork and wait for the child to exit.
