### PR TITLE
Add YAML exporter.

### DIFF
--- a/lib/foreman/export/yaml.rb
+++ b/lib/foreman/export/yaml.rb
@@ -1,0 +1,12 @@
+require "foreman/export"
+require "yaml"
+
+class Foreman::Export::Yaml < Foreman::Export::Base
+
+  def export
+    super
+    clean "#{location}/#{app}.yml"
+    write_template "yaml/app.yml.erb", "#{app}.yml", binding
+  end
+
+end

--- a/spec/foreman/export/yaml_spec.rb
+++ b/spec/foreman/export/yaml_spec.rb
@@ -1,0 +1,37 @@
+require "spec_helper"
+require "foreman/engine"
+require "foreman/export/yaml"
+require "tmpdir"
+
+describe Foreman::Export::Yaml, :fakefs do
+  let(:procfile)  { FileUtils.mkdir_p("/tmp/app"); write_procfile("/tmp/app/Procfile") }
+  let(:formation) { nil }
+  let(:engine)    { Foreman::Engine.new(:formation => formation).load_procfile(procfile) }
+  let(:options)   { Hash.new }
+  let(:yaml)      { Foreman::Export::Yaml.new("/tmp/init", engine, options) }
+
+  before(:each) { load_export_templates_into_fakefs("yaml") }
+  before(:each) { stub(yaml).say }
+
+  it "exports to the filesystem" do
+    yaml.export
+    normalize_space(File.read("/tmp/init/app.yml")).should == normalize_space(example_export_file("yaml/app.yml"))
+  end
+
+  it "cleans up if exporting into an existing dir" do
+    mock(FileUtils).rm("/tmp/init/app.yml")
+
+    yaml.export
+    yaml.export
+  end
+
+  context "with a process formation" do
+    let(:formation) { "alpha=2" }
+
+    it "exports to the filesystem with concurrency" do
+      yaml.export
+      normalize_space(File.read("/tmp/init/app.yml")).should == normalize_space(example_export_file("yaml/app-concurrency.yml"))
+    end
+  end
+
+end

--- a/spec/resources/export/yaml/app-concurrency.yml
+++ b/spec/resources/export/yaml/app-concurrency.yml
@@ -1,0 +1,29 @@
+---
+app: app
+log: /var/log/app
+user: app
+environment:
+processes:
+  - name: alpha
+    command: ./alpha
+    count: 2
+  - name: bravo
+    command: ./bravo
+    count: 0
+  - name: foo_bar
+    command: ./foo_bar
+    count: 0
+  - name: foo-bar
+    command: ./foo-bar
+    count: 0
+instances:
+  - name: app-alpha-1
+    process: alpha
+    port: 5000
+    command: "./alpha"
+    expanded_command: "./alpha"
+  - name: app-alpha-2
+    process: alpha
+    port: 5001
+    command: "./alpha"
+    expanded_command: "./alpha"

--- a/spec/resources/export/yaml/app.yml
+++ b/spec/resources/export/yaml/app.yml
@@ -1,0 +1,39 @@
+---
+app: app
+log: /var/log/app
+user: app
+environment:
+processes:
+  - name: alpha
+    command: ./alpha
+    count: 1
+  - name: bravo
+    command: ./bravo
+    count: 1
+  - name: foo_bar
+    command: ./foo_bar
+    count: 1
+  - name: foo-bar
+    command: ./foo-bar
+    count: 1
+instances:
+  - name: app-alpha-1
+    process: alpha
+    port: 5000
+    command: "./alpha"
+    expanded_command: "./alpha"
+  - name: app-bravo-1
+    process: bravo
+    port: 5100
+    command: "./bravo"
+    expanded_command: "./bravo"
+  - name: app-foo_bar-1
+    process: foo_bar
+    port: 5200
+    command: "./foo_bar"
+    expanded_command: "./foo_bar"
+  - name: app-foo-bar-1
+    process: foo-bar
+    port: 5300
+    command: "./foo-bar"
+    expanded_command: "./foo-bar"


### PR DESCRIPTION
This exports the foreman configuration in a YAML file that other tools can read, so the tools don't need to understand how to parse a Procfile.

My concrete use case is that I want to write a tool that tells me what ports are assigned on a server. I plan to run `foreman export yaml` at the same time as `foreman export systemd`, with the exact same parameters, and keep the .yml file around and use it with other tools.

Would you please consider merging this feature?
