### PR TITLE
Ninefold/feature fix env escaping

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,8 @@
-## 0.64.0 (2013-12-11)
+## 0.63.101 (2013-12-18)
+
+* 9F: Stop shell quoting - it's unnecessary
+
+## 0.63.100 (2013-12-11)
 
 * 9F: Export environment variables outside of the running command
 

--- a/data/export/upstart/process.conf.erb
+++ b/data/export/upstart/process.conf.erb
@@ -4,7 +4,7 @@ respawn
 
 env PORT=<%= port %>
 <% engine.env.each_pair do |var,env| -%>
-env <%= var.upcase %>=<%= shell_quote(env) %>
+env <%= var.upcase %>=<%= env %>
 <% end -%>
 
 exec su <%= user %> -l -m -c 'cd <%= engine.root %>; <%= process.command %> >> <%= log %>/<%=name%>-<%=num%>.log 2>&1'

--- a/lib/foreman/version.rb
+++ b/lib/foreman/version.rb
@@ -1,5 +1,5 @@
 module Foreman
 
-  VERSION = "0.63.100"
+  VERSION = "0.63.101"
 
 end


### PR DESCRIPTION
The shell quoting is unnecessary here. The user needs to ensure the environment variables are shell compatible.
