### PR TITLE
Test to see if we can already write to chowned dir's if chown fails

### DIFF
--- a/lib/foreman/export/base.rb
+++ b/lib/foreman/export/base.rb
@@ -48,8 +48,8 @@ class Foreman::Export::Base
     FileUtils.mkdir_p(location) rescue error("Could not create: #{location}")
     FileUtils.mkdir_p(log) rescue error("Could not create: #{log}")
     FileUtils.mkdir_p(run) rescue error("Could not create: #{run}")
-    FileUtils.chown(user, nil, log) rescue error("Could not chown #{log} to #{user}")
-    FileUtils.chown(user, nil, run) rescue error("Could not chown #{run} to #{user}")
+    chown user, log
+    chown user, run
   end
 
   def app
@@ -80,6 +80,12 @@ private ######################################################################
     puts "https://github.com/ddollar/foreman/blob/master/data/export/upstart/process.conf.erb"
     puts
     @@deprecation_warned = true
+  end
+
+  def chown user, dir
+    FileUtils.chown user, nil, dir
+  rescue
+    error("Could not chown #{dir} to #{user}") unless File.writable? dir
   end
 
   def error(message)


### PR DESCRIPTION
`chown` will fail if we aren't root, but in some cases this is perfectly allowable (e.g. if the directories we are chowning are already writable due to being in the same group, or world writable), this patch will supress the error if that's the case.
