### PR TITLE
Fixes supervisord export not properly quoting environment values.

### DIFF
--- a/data/export/supervisord/app.conf.erb
+++ b/data/export/supervisord/app.conf.erb
@@ -5,7 +5,7 @@ engine.each_process do |name, process|
     port = engine.port_for(process, num)
     full_name = "#{app}-#{name}-#{num}"
     environment = engine.env.merge("PORT" => port.to_s).map do |key, value|
-      "#{key}=#{shell_quote(value)}"
+      "#{key}=\"#{shell_quote(value)}\""
     end
     app_names << full_name
 %>

--- a/spec/resources/export/supervisord/app-alpha-1.conf
+++ b/spec/resources/export/supervisord/app-alpha-1.conf
@@ -8,7 +8,7 @@ stdout_logfile=/var/log/app/alpha-1.log
 stderr_logfile=/var/log/app/alpha-1.error.log
 user=app
 directory=/tmp/app
-environment=PORT=5000
+environment=PORT="5000"
 [program:app-bravo-1]
 command=./bravo
 autostart=true
@@ -18,7 +18,7 @@ stdout_logfile=/var/log/app/bravo-1.log
 stderr_logfile=/var/log/app/bravo-1.error.log
 user=app
 directory=/tmp/app
-environment=PORT=5100
+environment=PORT="5100"
 [program:app-foo_bar-1]
 command=./foo_bar
 autostart=true
@@ -28,7 +28,7 @@ stdout_logfile=/var/log/app/foo_bar-1.log
 stderr_logfile=/var/log/app/foo_bar-1.error.log
 user=app
 directory=/tmp/app
-environment=PORT=5200
+environment=PORT="5200"
 [program:app-foo-bar-1]
 command=./foo-bar
 autostart=true
@@ -38,7 +38,7 @@ stdout_logfile=/var/log/app/foo-bar-1.log
 stderr_logfile=/var/log/app/foo-bar-1.error.log
 user=app
 directory=/tmp/app
-environment=PORT=5300
+environment=PORT="5300"
 
 [group:app]
 programs=app-alpha-1,app-bravo-1,app-foo_bar-1,app-foo-bar-1

--- a/spec/resources/export/supervisord/app-alpha-2.conf
+++ b/spec/resources/export/supervisord/app-alpha-2.conf
@@ -8,7 +8,7 @@ stdout_logfile=/var/log/app/alpha-1.log
 stderr_logfile=/var/log/app/alpha-1.error.log
 user=app
 directory=/tmp/app
-environment=PORT=5000
+environment=PORT="5000"
 [program:app-alpha-2]
 command=./alpha
 autostart=true
@@ -18,7 +18,7 @@ stdout_logfile=/var/log/app/alpha-2.log
 stderr_logfile=/var/log/app/alpha-2.error.log
 user=app
 directory=/tmp/app
-environment=PORT=5001
+environment=PORT="5001"
 
 [group:app]
 programs=app-alpha-1,app-alpha-2


### PR DESCRIPTION
Hey there,

I've been playing around with `foreman export supervisord` and noticed that supervisord crashes with environment values that aren't properly quoted.

Per http://supervisord.org/configuration.html:

> environment:
> 
> > Values containing non-alphanumeric characters should be quoted (e.g. KEY="val:123",KEY2="val,456").

This patch always quotes the value. What do you think?

Thanks!
