### PR TITLE
Exec process, otherwise only the shell receives signal.

### DIFF
--- a/lib/foreman/process.rb
+++ b/lib/foreman/process.rb
@@ -59,7 +59,7 @@ class Foreman::Process
       wrapped_command = "#{runner} -d '#{cwd.shellescape}' -p -- #{expanded_command(env)}"
       POSIX::Spawn.spawn(*spawn_args(env, wrapped_command.shellsplit, {:out => output, :err => output}))
     else
-      wrapped_command = "#{runner} -d '#{cwd.shellescape}' -p -- #{command}"
+      wrapped_command = "exec #{runner} -d '#{cwd.shellescape}' -p -- #{command}"
       Process.spawn env, wrapped_command, :out => output, :err => output
     end
   end


### PR DESCRIPTION
I found an issue by having a Procfile with an invalid command and then a valid executable.  If I did foreman stop it would bail, as expected.  However what wasn't expected was the valid command's signal handlers were never called and the process was left running.  What was also interesting, if I ran with a valid procfile, and forced shutdown on one process, the other exectuable with a signal handler's process would be removed but again it didn't appear the signal handler was called.

I traced this to the Process.spawn running the 'shell' version of spawn.  I think it has to do this to change the environment, but it means that the shell wraps the Foreman runner in a child process.  This means the signals being sent to the process by Foreman are swallowed by the shell and never sent to the foreman runner process (which does exec the original command).  

I added exec to the front of the wrapped command.  This fixes my issue, I am unsure how portable this is for various shells.  Perhaps someone can improve this. 
