### PR TITLE
Fix mkdir mode flag when creating runit log directories

### DIFF
--- a/data/export/runit/log/run.erb
+++ b/data/export/runit/log/run.erb
@@ -3,5 +3,5 @@ set -e
 
 LOG=<%= log %>/<%= name %>-<%= num %>
 
-test -d "$LOG" || mkdir -p m2750 "$LOG" && chown <%= user %> "$LOG"
+test -d "$LOG" || mkdir -p -m 2750 "$LOG" && chown <%= user %> "$LOG"
 exec chpst -u <%= user %> svlogd "$LOG"

--- a/spec/resources/export/runit/app-alpha-1/log/run
+++ b/spec/resources/export/runit/app-alpha-1/log/run
@@ -3,5 +3,5 @@ set -e
 
 LOG=/var/log/app/alpha-1
 
-test -d "$LOG" || mkdir -p m2750 "$LOG" && chown app "$LOG"
+test -d "$LOG" || mkdir -p -m 2750 "$LOG" && chown app "$LOG"
 exec chpst -u app svlogd "$LOG"

--- a/spec/resources/export/runit/app-alpha-2/log/run
+++ b/spec/resources/export/runit/app-alpha-2/log/run
@@ -3,5 +3,5 @@ set -e
 
 LOG=/var/log/app/alpha-2
 
-test -d "$LOG" || mkdir -p m2750 "$LOG" && chown app "$LOG"
+test -d "$LOG" || mkdir -p -m 2750 "$LOG" && chown app "$LOG"
 exec chpst -u app svlogd "$LOG"

--- a/spec/resources/export/runit/app-bravo-1/log/run
+++ b/spec/resources/export/runit/app-bravo-1/log/run
@@ -3,5 +3,5 @@ set -e
 
 LOG=/var/log/app/bravo-1
 
-test -d "$LOG" || mkdir -p m2750 "$LOG" && chown app "$LOG"
+test -d "$LOG" || mkdir -p -m 2750 "$LOG" && chown app "$LOG"
 exec chpst -u app svlogd "$LOG"


### PR DESCRIPTION
The mode flag for creating log directories in the runit exporter is malformed, and so it was creating a directory called "m2750" instead of setting the permissions on the log directory.
