### PR TITLE
Add an extra ../ when calculating relative paths

### DIFF
--- a/dist/resources/tgz/foreman
+++ b/dist/resources/tgz/foreman
@@ -3,12 +3,12 @@
 require "pathname"
 bin_file = Pathname.new(__FILE__).realpath
 
-gem_dir = File.expand_path("../vendor/gems", bin_file)
+gem_dir = File.expand_path("../../vendor/gems", bin_file)
   Dir["#{gem_dir}/**/lib"].each do |libdir|
   $:.unshift libdir
 end
 
-$:.unshift File.expand_path("../lib", bin_file)
+$:.unshift File.expand_path("../../lib", bin_file)
 
 require "foreman/cli"
 


### PR DESCRIPTION
If the `foreman` script lives inside `bin/`, we need an extra `../` when calculating paths to `vendor/` and `lib/`, otherwise we end up putting paths like `path/to/foreman/bin/lib` on `$LOAD_PATH`.

cc @ddollar @wfarr
