### PR TITLE
allow dotenv 0.x

### DIFF
--- a/foreman.gemspec
+++ b/foreman.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.files << "man/foreman.1"
 
   gem.add_dependency 'thor', '>= 0.13.6'
-  gem.add_dependency 'dotenv', '~> 0.7.0'
+  gem.add_dependency 'dotenv', '~> 0.7'
 
   if ENV["PLATFORM"] == "java"
     gem.platform = Gem::Platform.new("java")


### PR DESCRIPTION
dotenv 0.11.1 fixes the problem that prompted 5c946e2d558ad1b22c6ae2ec0789a72dfbc95780 - i think it was just a fluke that it was broken
