### PR TITLE
use dotenv 0.11.x

### DIFF
--- a/foreman.gemspec
+++ b/foreman.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.files << "man/foreman.1"
 
   gem.add_dependency 'thor', '>= 0.13.6'
-  gem.add_dependency 'dotenv', '~> 0.7.0'
+  gem.add_dependency 'dotenv', '~> 0.11.1'
 
   if ENV["PLATFORM"] == "java"
     gem.platform = Gem::Platform.new("java")


### PR DESCRIPTION
this is a less loose version of #436

0.11.x allows the use of `dotenv-deployment` which is a significant improvement over 0.7.x
