### PR TITLE
Clean up upstart export to use native upstart features

### DIFF
--- a/data/export/upstart/master.conf.erb
+++ b/data/export/upstart/master.conf.erb
@@ -1,12 +1,2 @@
-pre-start script
-
-bash << "EOF"
-  mkdir -p <%= log %>
-  chown -R <%= user %> <%= log %>
-EOF
-
-end script
-
 start on runlevel [2345]
-
-stop on runlevel [016]
+stop on runlevel [!2345]

--- a/data/export/upstart/process.conf.erb
+++ b/data/export/upstart/process.conf.erb
@@ -2,4 +2,13 @@ start on starting <%= app %>-<%= name %>
 stop on stopping <%= app %>-<%= name %>
 respawn
 
-exec su - <%= user %> -c 'cd <%= engine.root %>; export PORT=<%= port %>;<% engine.env.each_pair do |var,env| %> export <%= var.upcase %>=<%= shell_quote(env) %>; <% end %> <%= process.command %> >> <%= log %>/<%=name%>-<%=num%>.log 2>&1'
+env PORT=<%= port %>
+<% engine.env.each do |name,value| -%>
+env <%= name.upcase %>='<%= value.gsub(/'/, "'\"'\"'") %>'
+<% end -%>
+
+setuid <%= user %>
+
+chdir <%= engine.root %>
+
+exec <%= process.command %>


### PR DESCRIPTION
The old upstart used a big ugly line with `su`, `export`, `sh` and other evilness. Aside from this, it was also a significant security vulnerability as anyone with access to the box could run `ps` and see all the variables, including things like database credentials.
This change makes the upstart config use the native features of upstart itself.

This is the solution to the discussion mentioned in #397
