### PR TITLE
add logging back into upstart exports.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,6 +13,8 @@ GEM
       mime-types
       xml-simple
     builder (3.2.2)
+    codeclimate-test-reporter (0.3.0)
+      simplecov (>= 0.7.1, < 1.0.0)
     diff-lcs (1.2.5)
     docile (1.1.3)
     dotenv (0.7.0)
@@ -55,6 +57,7 @@ PLATFORMS
 
 DEPENDENCIES
   aws-s3
+  codeclimate-test-reporter
   fakefs (~> 0.3.2)
   foreman!
   rake

--- a/data/export/upstart/process.conf.erb
+++ b/data/export/upstart/process.conf.erb
@@ -11,4 +11,4 @@ setuid <%= user %>
 
 chdir <%= engine.root %>
 
-exec <%= process.command %>
+exec <%= process.command %> >> <%= log %>/<%=name%>-<%=num%>.log 2>&1

--- a/spec/resources/export/upstart/app-alpha-1.conf
+++ b/spec/resources/export/upstart/app-alpha-1.conf
@@ -8,4 +8,4 @@ setuid app
 
 chdir /tmp/app
 
-exec ./alpha
+exec ./alpha >> /var/log/app/alpha-1.log 2>&1

--- a/spec/resources/export/upstart/app-alpha-2.conf
+++ b/spec/resources/export/upstart/app-alpha-2.conf
@@ -8,4 +8,4 @@ setuid app
 
 chdir /tmp/app
 
-exec ./alpha
+exec ./alpha >> /var/log/app/alpha-2.log 2>&1

--- a/spec/resources/export/upstart/app-bravo-1.conf
+++ b/spec/resources/export/upstart/app-bravo-1.conf
@@ -8,4 +8,4 @@ setuid app
 
 chdir /tmp/app
 
-exec ./bravo
+exec ./bravo >> /var/log/app/bravo-1.log 2>&1


### PR DESCRIPTION
Looks like logging got removed from the last upstart export template. I added it back in, updated the specs, and checked it in real life.

Was there a reason it was removed? Logging seems to be in the other templates still.

Please let me know if you have any questions!
