### PR TITLE
Refactor foreman debian dependencies

### DIFF
--- a/dist/resources/deb/control
+++ b/dist/resources/deb/control
@@ -3,7 +3,7 @@ Version: <%= version %>
 Section: main
 Priority: standard
 Architecture: all
-Depends: ruby1.9.1
+Depends: ruby2.1|ruby2.0|ruby1.9.1
 Maintainer: Heroku
 Description: Manage Procfile-based applications.
  Foreman is a manager for Procfile-based applications. Its aim is to

--- a/dist/resources/deb/foreman
+++ b/dist/resources/deb/foreman
@@ -1,4 +1,4 @@
-#!/usr/bin/env ruby1.9.1
+#!/usr/bin/env ruby
 
 # resolve bin path, ignoring symlinks
 require "pathname"


### PR DESCRIPTION
This will allow foreman to be installable across more debian distros as
it increases the officially supported ruby packages that foreman depends
on.  The debian project has deprecated the ruby1.9.1 package in testing
(currently jessie), and this will soon propagate to other debian
derivatives.
