### PR TITLE
refactor upstart export

### DIFF
--- a/lib/foreman/export/upstart.rb
+++ b/lib/foreman/export/upstart.rb
@@ -10,16 +10,30 @@ class Foreman::Export::Upstart < Foreman::Export::Base
       clean file
     end
 
-    write_template "upstart/master.conf.erb", "#{app}.conf", binding
+    write_template master_template, "#{app}.conf", binding
 
     engine.each_process do |name, process|
       next if engine.formation[name] < 1
-      write_template "upstart/process_master.conf.erb", "#{app}-#{name}.conf", binding
+      write_template process_master_template, "#{app}-#{name}.conf", binding
 
       1.upto(engine.formation[name]) do |num|
         port = engine.port_for(process, num)
-        write_template "upstart/process.conf.erb", "#{app}-#{name}-#{num}.conf", binding
+        write_template process_template, "#{app}-#{name}-#{num}.conf", binding
       end
     end
+  end
+
+  private
+
+  def master_template
+    "upstart/master.conf.erb"
+  end
+
+  def process_master_template
+    "upstart/process_master.conf.erb"
+  end
+
+  def process_template
+    "upstart/process.conf.erb"
   end
 end


### PR DESCRIPTION
I needed to create a custom template to support an older version of upstart where `setuid` is not supported. This tiny refactor makes it easier to inherit from `Foreman::Export::Upstart` and override the methods `master_template` to `process_master_template` and `process_template` to provide a customized export.
