### PR TITLE
prevent windows from crashing on startup

### DIFF
--- a/lib/foreman/engine.rb
+++ b/lib/foreman/engine.rb
@@ -369,7 +369,7 @@ private
 
   def read_self_pipe
     @selfpipe[:reader].read_nonblock(11)
-  rescue Errno::EAGAIN, Errno::EINTR => err
+  rescue Errno::EAGAIN, Errno::EINTR, Errno::EBADF
     # ignore
   end
 


### PR DESCRIPTION
this isn't a beautiful solution since it will still throw an exception instead of gracefully failing under one of the interrupts, but it makes it usable on windows at least
