### PR TITLE
Use dotenv 1.0.

### DIFF
--- a/foreman.gemspec
+++ b/foreman.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.files << "man/foreman.1"
 
   gem.add_dependency 'thor', '~> 0.19.1'
-  gem.add_dependency 'dotenv', '~> 0.11.1'
+  gem.add_dependency 'dotenv', '~> 1.0.1'
 
   if ENV["PLATFORM"] == "mingw32"
     gem.add_dependency "win32console", "~> 1.3.0"


### PR DESCRIPTION
Hello!

I want to upgrade my dotenv-rails but it depends on dotenv 1.0.1.

And foreman dpeneds on 0.11.1.

So should we bump dotenv version?

Here is the dotenv changelog: https://github.com/bkeepers/dotenv/blob/master/Changelog.md

Thank you.
