### PR TITLE
Preventing SIGINT from killing `foreman run` directly

### DIFF
--- a/lib/foreman/cli.rb
+++ b/lib/foreman/cli.rb
@@ -96,6 +96,9 @@ class Foreman::CLI < Thor
         error "command not found: #{args.first}"
       end
     end
+    trap("INT") do
+      Process.kill(:INT, pid)
+    end
     Process.wait(pid)
     exit $?.exitstatus
   rescue Interrupt


### PR DESCRIPTION
This should resolve #489. By trapping SIGINT, we prevent the foreman process from bailing on a ctrl-c. In the trap we pass the SIGINT through to the child process. If that results in the child process dying, foreman exits as normal, but it doesn't hijack the lifecycle of the child process anymore.
