### PR TITLE
Nicer formatting for exported supervisord files

### DIFF
--- a/data/export/supervisord/app.conf.erb
+++ b/data/export/supervisord/app.conf.erb
@@ -8,7 +8,7 @@ engine.each_process do |name, process|
       "#{key}=\"#{shell_quote(value)}\""
     end
     app_names << full_name
-%>
+-%>
 [program:<%= full_name %>]
 command=<%= process.command %>
 autostart=true
@@ -18,10 +18,11 @@ stdout_logfile=<%= log %>/<%= name %>-<%= num %>.log
 stderr_logfile=<%= log %>/<%= name %>-<%= num %>.error.log
 user=<%= user %>
 directory=<%= engine.root %>
-environment=<%= environment.join(',') %><%
+environment=<%= environment.join(',') %>
+
+<%
   end
 end
-%>
-
+-%>
 [group:<%= app %>]
 programs=<%= app_names.join(',') %>

--- a/spec/resources/export/supervisord/app-alpha-1.conf
+++ b/spec/resources/export/supervisord/app-alpha-1.conf
@@ -1,4 +1,3 @@
-
 [program:app-alpha-1]
 command=./alpha
 autostart=true
@@ -9,6 +8,7 @@ stderr_logfile=/var/log/app/alpha-1.error.log
 user=app
 directory=/tmp/app
 environment=PORT="5000"
+
 [program:app-bravo-1]
 command=./bravo
 autostart=true
@@ -19,6 +19,7 @@ stderr_logfile=/var/log/app/bravo-1.error.log
 user=app
 directory=/tmp/app
 environment=PORT="5100"
+
 [program:app-foo_bar-1]
 command=./foo_bar
 autostart=true
@@ -29,6 +30,7 @@ stderr_logfile=/var/log/app/foo_bar-1.error.log
 user=app
 directory=/tmp/app
 environment=PORT="5200"
+
 [program:app-foo-bar-1]
 command=./foo-bar
 autostart=true

--- a/spec/resources/export/supervisord/app-alpha-2.conf
+++ b/spec/resources/export/supervisord/app-alpha-2.conf
@@ -1,4 +1,3 @@
-
 [program:app-alpha-1]
 command=./alpha
 autostart=true
@@ -9,6 +8,7 @@ stderr_logfile=/var/log/app/alpha-1.error.log
 user=app
 directory=/tmp/app
 environment=PORT="5000"
+
 [program:app-alpha-2]
 command=./alpha
 autostart=true


### PR DESCRIPTION
1. Remove newline from beginning of supervisord files
2. Put blank lines between [program] sections for readability
##### Example:

``` ini
[program:app-alpha-1]
command=./alpha
autostart=true
autorestart=true
stopsignal=QUIT
stdout_logfile=/var/log/app/alpha-1.log
stderr_logfile=/var/log/app/alpha-1.error.log
user=app
directory=/tmp/app
environment=PORT="5000"

[program:app-alpha-2]
command=./alpha
autostart=true
autorestart=true
stopsignal=QUIT
stdout_logfile=/var/log/app/alpha-2.log
stderr_logfile=/var/log/app/alpha-2.error.log
user=app
directory=/tmp/app
environment=PORT="5001"

[group:app]
programs=app-alpha-1,app-alpha-2
```
##### Tests:

```
$ bundle exec rake spec
/Users/marca/.rvm/rubies/ruby-2.1.2/bin/ruby -S rspec spec/foreman/cli_spec.rb spec/foreman/engine_spec.rb spec/foreman/export/base_spec.rb spec/foreman/export/bluepill_spec.rb spec/foreman/export/daemon_spec.rb spec/foreman/export/inittab_spec.rb spec/foreman/export/launchd_spec.rb spec/foreman/export/runit_spec.rb spec/foreman/export/supervisord_spec.rb spec/foreman/export/systemd_spec.rb spec/foreman/export/upstart_spec.rb spec/foreman/export_spec.rb spec/foreman/helpers_spec.rb spec/foreman/process_spec.rb spec/foreman/procfile_spec.rb spec/foreman_spec.rb spec/helper_spec.rb
I, [2014-11-27T08:12:18.789614 #50079]  INFO -- : Not reporting to Code Climate because ENV['CODECLIMATE_REPO_TOKEN'] is not set.
..................................................................................

Finished in 4.68 seconds
82 examples, 0 failures

Randomized with seed 15318

Coverage report generated for RSpec to /Users/marca/dev/git-repos/foreman/coverage. 579 / 670 LOC (86.42%) covered.
```
