### PR TITLE
When exporting upstart configs only relevant files should be deleted.

### DIFF
--- a/lib/foreman/export/upstart.rb
+++ b/lib/foreman/export/upstart.rb
@@ -6,24 +6,33 @@ class Foreman::Export::Upstart < Foreman::Export::Base
   def export
     super
 
-    (Dir["#{location}/#{app}-*.conf"] << "#{location}/#{app}.conf").each do |file|
-      clean file
-    end
+    master_file = "#{app}.conf"
 
-    write_template master_template, "#{app}.conf", binding
+    clean master_file
+    write_template master_template, master_file, binding
 
     engine.each_process do |name, process|
+      process_master_file = "#{app}-#{name}.conf"
+      clean process_master_file
+
       next if engine.formation[name] < 1
-      write_template process_master_template, "#{app}-#{name}.conf", binding
+      write_template process_master_template, process_master_file, binding
 
       1.upto(engine.formation[name]) do |num|
         port = engine.port_for(process, num)
-        write_template process_template, "#{app}-#{name}-#{num}.conf", binding
+        process_file = "#{app}-#{name}-#{num}.conf"
+        clean process_file
+        write_template process_template, process_file, binding
       end
     end
   end
 
   private
+
+  def clean(file_name)
+    path = File.expand_path(File.join(location, file_name))
+    super path
+  end
 
   def master_template
     "upstart/master.conf.erb"

--- a/lib/foreman/export/upstart.rb
+++ b/lib/foreman/export/upstart.rb
@@ -8,12 +8,12 @@ class Foreman::Export::Upstart < Foreman::Export::Base
 
     master_file = "#{app}.conf"
 
-    clean master_file
+    clean File.join(location, master_file)
     write_template master_template, master_file, binding
 
     engine.each_process do |name, process|
       process_master_file = "#{app}-#{name}.conf"
-      clean process_master_file
+      clean File.join(location, process_master_file)
 
       next if engine.formation[name] < 1
       write_template process_master_template, process_master_file, binding
@@ -21,18 +21,13 @@ class Foreman::Export::Upstart < Foreman::Export::Base
       1.upto(engine.formation[name]) do |num|
         port = engine.port_for(process, num)
         process_file = "#{app}-#{name}-#{num}.conf"
-        clean process_file
+        clean File.join(location, process_file)
         write_template process_template, process_file, binding
       end
     end
   end
 
   private
-
-  def clean(file_name)
-    path = File.expand_path(File.join(location, file_name))
-    super path
-  end
 
   def master_template
     "upstart/master.conf.erb"

--- a/spec/foreman/export/upstart_spec.rb
+++ b/spec/foreman/export/upstart_spec.rb
@@ -50,6 +50,20 @@ describe Foreman::Export::Upstart, :fakefs do
     upstart.export
   end
 
+  it 'does not delete exported files for app which share name prefix' do
+    FileUtils.mkdir_p "/tmp/init"
+
+    ["app-worker", "app-worker-worker", "app-worker-worker-1"].each do |name|
+      path = "/tmp/init/#{name}.conf"
+      FileUtils.touch(path)
+      dont_allow(FileUtils).rm(path)
+    end
+
+    upstart.export
+    expect(File.exist?('/tmp/init/app.conf')).to be true
+    expect(File.exist?('/tmp/init/app-worker.conf')).to be true
+  end
+
   it "quotes and escapes environment variables" do
     engine.env['KEY'] = 'd"\|d'
     upstart.export


### PR DESCRIPTION
This fixes #491 

It seems to work as expected now:

```
$ bundle exec ./bin/foreman export -f procf2 --app test-app-worker upstart .
[foreman export] writing: test-app-worker.conf
[foreman export] writing: test-app-worker-worker.conf
[foreman export] writing: test-app-worker-worker-1.conf
$ bundle exec ./bin/foreman export -f procf1 --app test-app upstart .
[foreman export] writing: test-app.conf
[foreman export] writing: test-app-web.conf
[foreman export] writing: test-app-web-1.conf
$ ls *.conf
test-app.conf  test-app-web-1.conf  test-app-web.conf  test-app-worker.conf  test-app-worker-worker-1.conf  test-app-worker-worker.conf
```

Of course if `procfile1` would have `worker:` entry then it would delete relevant files. I don't think there's a solution to this kind of situation, other than renaming the applications (which makes sense in my opinion).

Let me know what you think.

(I had no idea how to attach a Pull Request to existing issue, sorry! :bow: )