### PR TITLE
Do not parse options after "run" argument, to avoid conflicts.

### DIFF
--- a/lib/foreman/cli.rb
+++ b/lib/foreman/cli.rb
@@ -74,6 +74,7 @@ class Foreman::CLI < Thor
   desc "run COMMAND [ARGS...]", "Run a command using your application's environment"
 
   method_option :env, :type => :string, :aliases => "-e", :desc => "Specify an environment file to load, defaults to .env"
+  stop_on_unknown_option! :run
 
   def run(*args)
     load_environment!

--- a/spec/foreman/cli_spec.rb
+++ b/spec/foreman/cli_spec.rb
@@ -76,6 +76,10 @@ describe "Foreman::CLI", :fakefs do
       expect(forked_foreman("run echo 1")).to eq("1\n")
     end
 
+    it "doesn't parse options for the command" do
+      expect(forked_foreman("run grep -e FOO #{resource_path(".env")}")).to eq("FOO=bar\n")
+    end
+
     it "includes the environment" do
       expect(forked_foreman("run #{resource_path("bin/env FOO")} -e #{resource_path(".env")}")).to eq("bar\n")
     end

--- a/spec/foreman/cli_spec.rb
+++ b/spec/foreman/cli_spec.rb
@@ -81,7 +81,7 @@ describe "Foreman::CLI", :fakefs do
     end
 
     it "includes the environment" do
-      expect(forked_foreman("run #{resource_path("bin/env FOO")} -e #{resource_path(".env")}")).to eq("bar\n")
+      expect(forked_foreman("run -e #{resource_path(".env")} #{resource_path("bin/env FOO")}")).to eq("bar\n")
     end
 
     it "can run a command from the Procfile" do


### PR DESCRIPTION
Right now, when using `foreman run`, Thor is instructed to parse all command line options, including those that are in fact passed to the executed command.

For instance, this command mysteriously fails:
```
$ foreman run go test -test.v=1 -cover ./...
/Users/rasky/.gem/gems/dotenv-1.0.2/lib/dotenv/environment.rb:14:in `read': No such file or directory - env (Errno::ENOENT)
	from /Users/rasky/.gem/gems/dotenv-1.0.2/lib/dotenv/environment.rb:14:in `read'
	from /Users/rasky/.gem/gems/dotenv-1.0.2/lib/dotenv/environment.rb:10:in `load'
	from /Users/rasky/.gem/gems/dotenv-1.0.2/lib/dotenv/environment.rb:6:in `initialize'
	from /Users/rasky/.gem/gems/foreman-0.77.0/lib/foreman/engine.rb:172:in `new'
	from /Users/rasky/.gem/gems/foreman-0.77.0/lib/foreman/engine.rb:172:in `load_env'
	from /Users/rasky/.gem/gems/foreman-0.77.0/lib/foreman/cli.rb:142:in `block in load_environment!'
	from /Users/rasky/.gem/gems/foreman-0.77.0/lib/foreman/cli.rb:140:in `each'
	from /Users/rasky/.gem/gems/foreman-0.77.0/lib/foreman/cli.rb:140:in `load_environment!'
	from /Users/rasky/.gem/gems/foreman-0.77.0/lib/foreman/cli.rb:80:in `run'
	from /Users/rasky/.gem/gems/thor-0.19.1/lib/thor/command.rb:27:in `run'
	from /Users/rasky/.gem/gems/thor-0.19.1/lib/thor/invocation.rb:126:in `invoke_command'
	from /Users/rasky/.gem/gems/thor-0.19.1/lib/thor.rb:359:in `dispatch'
	from /Users/rasky/.gem/gems/thor-0.19.1/lib/thor/base.rb:440:in `start'
	from /Users/rasky/.gem/gems/foreman-0.77.0/bin/foreman:7:in `<top (required)>'
	from /Users/rasky/.gem/bin/foreman:23:in `load'
	from /Users/rasky/.gem/bin/foreman:23:in `<main>'
```

because `-cover` is parsed in UNIX-style composed mode, and thus `-e` is found and used. Notice that it's all pretty casual for the user, as the following command works perfectly:

```
$ foreman run go test -test.v=1 ./...
```

probably because `-test.v` is skipped by Thor because it contains a dot.

By instructing Thor to ignore all command line options after the first argument, the problem is fixed. `run`-specific options can still be passed before the command name, eg:

```
$ foreman run -e .env2 go test -cover ./...
```

which is very intuitive for the users, and probably what they already do.