### PR TITLE
Colored output and bright colors

### DIFF
--- a/lib/foreman/cli.rb
+++ b/lib/foreman/cli.rb
@@ -21,6 +21,7 @@ class Foreman::CLI < Thor
 
   method_option :color,          :type => :boolean, :aliases => "-c", :desc => "Force color to be enabled"
   method_option :colored_output, :type => :boolean, :aliases => "-C", :desc => "Force output to be colored"
+  method_option :bright_colors,  :type => :boolean, :aliases => "-B", :desc => "Enable bright colors"
   method_option :env,            :type => :string,  :aliases => "-e", :desc => "Specify an environment file to load, defaults to .env"
   method_option :formation,      :type => :string,  :aliases => "-m", :banner => '"alpha=5,bar=3"'
   method_option :port,           :type => :numeric, :aliases => "-p"

--- a/lib/foreman/cli.rb
+++ b/lib/foreman/cli.rb
@@ -19,11 +19,12 @@ class Foreman::CLI < Thor
 
   desc "start [PROCESS]", "Start the application (or a specific PROCESS)"
 
-  method_option :color,     :type => :boolean, :aliases => "-c", :desc => "Force color to be enabled"
-  method_option :env,       :type => :string,  :aliases => "-e", :desc => "Specify an environment file to load, defaults to .env"
-  method_option :formation, :type => :string,  :aliases => "-m", :banner => '"alpha=5,bar=3"'
-  method_option :port,      :type => :numeric, :aliases => "-p"
-  method_option :timeout,   :type => :numeric, :aliases => "-t", :desc => "Specify the amount of time (in seconds) processes have to shutdown gracefully before receiving a SIGKILL, defaults to 5."
+  method_option :color,          :type => :boolean, :aliases => "-c", :desc => "Force color to be enabled"
+  method_option :colored_output, :type => :boolean, :aliases => "-C", :desc => "Force output to be colored"
+  method_option :env,            :type => :string,  :aliases => "-e", :desc => "Specify an environment file to load, defaults to .env"
+  method_option :formation,      :type => :string,  :aliases => "-m", :banner => '"alpha=5,bar=3"'
+  method_option :port,           :type => :numeric, :aliases => "-p"
+  method_option :timeout,        :type => :numeric, :aliases => "-t", :desc => "Specify the amount of time (in seconds) processes have to shutdown gracefully before receiving a SIGKILL, defaults to 5."
 
   class << self
     # Hackery. Take the run method away from Thor so that we can redefine it.

--- a/lib/foreman/engine/cli.rb
+++ b/lib/foreman/engine/cli.rb
@@ -58,8 +58,9 @@ class Foreman::Engine::CLI < Foreman::Engine
       output  = ""
       output += $stdout.color(@colors[name.split(".").first].to_sym)
       output += "#{Time.now.strftime("%H:%M:%S")} #{pad_process_name(name)} | "
-      output += $stdout.color(:reset)
+      output += $stdout.color(:reset) unless options[:colored_output]
       output += message
+      output += $stdout.color(:reset)
       $stdout.puts output
       $stdout.flush
     end

--- a/lib/foreman/engine/cli.rb
+++ b/lib/foreman/engine/cli.rb
@@ -24,9 +24,10 @@ class Foreman::Engine::CLI < Foreman::Engine
       :bright_white   => 37,
     }
 
-    def self.enable(io, force=false)
+    def self.enable(io, force=false, bright_colors=false)
       io.extend(self)
-      @@color_force = force
+      @@color_force   = force
+      @@bright_colors = bright_colors
     end
 
     def color?
@@ -39,7 +40,9 @@ class Foreman::Engine::CLI < Foreman::Engine
     def color(name)
       return "" unless color?
       return "" unless ansi = ANSI[name.to_sym]
-      "\e[#{ansi}m"
+      brightness = 0
+      brightness = (name.to_s['bright'] ? 1 : 0) if @@bright_colors
+      "\e[#{brightness};#{ansi}m"
     end
 
   end
@@ -50,7 +53,7 @@ class Foreman::Engine::CLI < Foreman::Engine
   def startup
     @colors = map_colors
     proctitle "foreman: master" unless Foreman.windows?
-    Color.enable($stdout, options[:color])
+    Color.enable($stdout, options[:color], options[:bright_colors])
   end
 
   def output(name, data)


### PR DESCRIPTION
There are two new options added:
 1. -C to color output;
 2. -B to enable bright/bold colors.