### PR TITLE
Work around potential nil $?

### DIFF
--- a/lib/foreman/cli.rb
+++ b/lib/foreman/cli.rb
@@ -101,7 +101,7 @@ class Foreman::CLI < Thor
       Process.kill(:INT, pid)
     end
     Process.wait(pid)
-    exit $?.exitstatus
+    exit $?.exitstatus || 0
   rescue Interrupt
   end
 


### PR DESCRIPTION
`Process.wait` populates `$?` from which the exit call reads the exit status, but if the `SIGINT` trap above (added in d0fbc51) fires and the process terminates itself in reaction to that forwarded `SIGINT`, then `$?` will be `nil` as the kill call terminated the process and there is nothing left to wait for:

```
foreman-0.77.0/lib/foreman/cli.rb:104:in `exit': no implicit conversion from nil to integer (TypeError)
	from foreman-0.77.0/lib/foreman/cli.rb:104:in `run'
	from thor-0.19.1/lib/thor/command.rb:27:in `run'
	from thor-0.19.1/lib/thor/invocation.rb:126:in `invoke_command'
	from thor-0.19.1/lib/thor.rb:359:in `dispatch'
	from thor-0.19.1/lib/thor/base.rb:440:in `start'
	from foreman-0.77.0/bin/foreman:7:in `<top (required)>'
	from foreman-0.77.0/bin/foreman:23:in `load'
	from foreman-0.77.0/bin/foreman:23:in `<main>'
```