### PR TITLE
Create a new process group when spawning a new process

### DIFF
--- a/lib/foreman/process.rb
+++ b/lib/foreman/process.rb
@@ -49,9 +49,9 @@ class Foreman::Process
     env    = @options[:env].merge(options[:env] || {})
     output = options[:output] || $stdout
     runner = "#{Foreman.runner}".shellescape
-    
+
     Dir.chdir(cwd) do
-      Process.spawn env, expanded_command(env), :out => output, :err => output
+      Process.spawn(env, expanded_command(env), :out => output, :err => output, :pgroup => true)
     end
   end
 


### PR DESCRIPTION
When a new process is created with `spawn`, it is placed in the same process group as its parent. SIGTSTP, SIGQUIT, and SIGINT signals generated by keyboard interrupts are automatically sent to all processes associated with the terminal, which leads to things like #525. This small patch makes the `spawn` call create a new process group.