### PR TITLE
Fix signal exception name

### DIFF
--- a/lib/foreman/engine.rb
+++ b/lib/foreman/engine.rb
@@ -85,7 +85,7 @@ class Foreman::Engine
     @selfpipe[:writer].write_nonblock( '.' )
   rescue Errno::EAGAIN
     # Ignore writes that would block
-  rescue Errno::EINT
+  rescue Errno::EINTR
     # Retry if another signal arrived while writing
     retry
   end


### PR DESCRIPTION
Correct exception name for EINTR. Should fix #527.