### PR TITLE
Support for passing multiple processes to foreman start

### DIFF
--- a/lib/foreman/cli.rb
+++ b/lib/foreman/cli.rb
@@ -17,7 +17,7 @@ class Foreman::CLI < Thor
   class_option :procfile, :type => :string, :aliases => "-f", :desc => "Default: Procfile"
   class_option :root,     :type => :string, :aliases => "-d", :desc => "Default: Procfile directory"
 
-  desc "start [PROCESS]", "Start the application (or a specific PROCESS)"
+  desc "start [PROCESSES]", "Start the application (or a specific space separated PROCESSES)"
 
   method_option :color,     :type => :boolean, :aliases => "-c", :desc => "Force color to be enabled"
   method_option :env,       :type => :string,  :aliases => "-e", :desc => "Specify an environment file to load, defaults to .env"

--- a/lib/foreman/cli.rb
+++ b/lib/foreman/cli.rb
@@ -33,11 +33,12 @@ class Foreman::CLI < Thor
     end
   end
 
-  def start(process=nil)
+  def start(*processes)
     check_procfile!
     load_environment!
     engine.load_procfile(procfile)
-    engine.options[:formation] = "#{process}=1" if process
+    formation = processes.map { |process| "#{process}=1" }.join(',')
+    engine.options[:formation] = formation if processes.any?
     engine.start
   end
 

--- a/man/foreman.1
+++ b/man/foreman.1
@@ -1,13 +1,13 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "FOREMAN" "1" "January 2015" "Foreman 0.77.0" "Foreman Manual"
+.TH "FOREMAN" "1" "March 2015" "Foreman 0.77.0" "Foreman Manual"
 .
 .SH "NAME"
 \fBforeman\fR \- manage Procfile\-based applications
 .
 .SH "SYNOPSIS"
-\fBforeman start [process]\fR
+\fBforeman start [processes]\fR
 .
 .br
 \fBforeman run <command>\fR
@@ -25,7 +25,7 @@ Foreman is a manager for Procfile\-based applications\. Its aim is to abstract a
 If no additional parameters are passed, foreman will run one instance of each type of process defined in your Procfile\.
 .
 .P
-If a parameter is passed, foreman will run one instance of the specified application type\.
+If a parameter is passed, foreman will run each instance of the specified space separated application type\.
 .
 .P
 The following options control how the application is run:
@@ -230,6 +230,19 @@ Start one instance of each process type, interleave the output on stdout:
 .nf
 
 $ foreman start
+.
+.fi
+.
+.IP "" 0
+.
+.P
+Start selected subset of processes, one instance per process:
+.
+.IP "" 4
+.
+.nf
+
+$ foreman start alpha bravo charlie
 .
 .fi
 .

--- a/man/foreman.1.ronn
+++ b/man/foreman.1.ronn
@@ -3,7 +3,7 @@ foreman(1) -- manage Procfile-based applications
 
 ## SYNOPSIS
 
-`foreman start [process]`<br>
+`foreman start [processes]`<br>
 `foreman run <command>`<br>
 `foreman export <format> [location]`
 
@@ -21,8 +21,8 @@ format.
 If no additional parameters are passed, foreman will run one instance of each
 type of process defined in your Procfile.
 
-If a parameter is passed, foreman will run one instance of the specified
-application type.
+If a parameter is passed, foreman will run each instance of the specified
+space separated application type.
 
 The following options control how the application is run:
 
@@ -182,6 +182,10 @@ name as keys. Example:
 Start one instance of each process type, interleave the output on stdout:
 
     $ foreman start
+
+Start selected subset of processes, one instance per process:
+
+    $ foreman start alpha bravo charlie
 
 Export the application in upstart format:
 

--- a/spec/foreman/cli_spec.rb
+++ b/spec/foreman/cli_spec.rb
@@ -36,6 +36,15 @@ describe "Foreman::CLI", :fakefs do
         end
       end
 
+      it "can run multiple commands" do
+        without_fakefs do
+          output = foreman("start echo env -f #{resource_path("Procfile")}")
+          expect(output).to match(/echo.1/)
+          expect(output).to match(/env.1/)
+          expect(output).not_to match(/test.1/)
+        end
+      end
+
       it "can run all commands" do
         without_fakefs do
           output = foreman("start -f #{resource_path("Procfile")} -e #{resource_path(".env")}")


### PR DESCRIPTION
It is compatible with previous syntax. Now you can pass couple of them instead one.