### PR TITLE
Vendored ‘dotenv’ gem.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ group :test do
   gem "simplecov", :require => false
   gem 'timecop'
   gem "codeclimate-test-reporter", :require => false
+  gem 'dotenv', '1.0.2', :path => 'vendor/dotenv-1.0.2'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,8 +2,12 @@ PATH
   remote: .
   specs:
     foreman (0.77.0)
-      dotenv (~> 1.0.2)
       thor (~> 0.19.1)
+
+PATH
+  remote: vendor/dotenv-1.0.2
+  specs:
+    dotenv (1.0.2)
 
 GEM
   remote: http://rubygems.org/
@@ -17,7 +21,6 @@ GEM
       simplecov (>= 0.7.1, < 1.0.0)
     diff-lcs (1.2.5)
     docile (1.1.3)
-    dotenv (1.0.2)
     fakefs (0.3.2)
     hpricot (0.8.6)
     hpricot (0.8.6-java)
@@ -58,6 +61,7 @@ PLATFORMS
 DEPENDENCIES
   aws-s3
   codeclimate-test-reporter
+  dotenv (= 1.0.2)!
   fakefs (~> 0.3.2)
   foreman!
   rake

--- a/foreman.gemspec
+++ b/foreman.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |gem|
   gem.files << "man/foreman.1"
 
   gem.add_dependency 'thor', '~> 0.19.1'
-  gem.add_dependency 'dotenv', '~> 1.0.2'
 
   if ENV["PLATFORM"] == "mingw32"
     gem.add_dependency "win32console", "~> 1.3.0"


### PR DESCRIPTION
Remove 'dotenv' dependency as per https://github.com/ddollar/foreman/issues/505 .