### PR TITLE
Add keep-file-descriptors option

### DIFF
--- a/lib/foreman/cli.rb
+++ b/lib/foreman/cli.rb
@@ -24,6 +24,7 @@ class Foreman::CLI < Thor
   method_option :formation, :type => :string,  :aliases => "-m", :banner => '"alpha=5,bar=3"'
   method_option :port,      :type => :numeric, :aliases => "-p"
   method_option :timeout,   :type => :numeric, :aliases => "-t", :desc => "Specify the amount of time (in seconds) processes have to shutdown gracefully before receiving a SIGKILL, defaults to 5."
+  method_option :keep_file_descriptors, :type => :boolean, :default => false, :desc => "Inherit file descriptors"
 
   class << self
     # Hackery. Take the run method away from Thor so that we can redefine it.
@@ -38,6 +39,7 @@ class Foreman::CLI < Thor
     load_environment!
     engine.load_procfile(procfile)
     engine.options[:formation] = "#{process}=1" if process
+    engine.options[:keep_file_descriptors] = true if options[:keep_file_descriptors]
     engine.start
   end
 

--- a/lib/foreman/engine.rb
+++ b/lib/foreman/engine.rb
@@ -21,9 +21,10 @@ class Foreman::Engine
   #
   # @param [Hash] options
   #
-  # @option options [String] :formation (all=1)    The process formation to use
-  # @option options [Fixnum] :port      (5000)     The base port to assign to processes
-  # @option options [String] :root      (Dir.pwd)  The root directory from which to run processes
+  # @option options [String]  :formation             (all=1)    The process formation to use
+  # @option options [Fixnum]  :port                  (5000)     The base port to assign to processes
+  # @option options [String]  :root                  (Dir.pwd)  The root directory from which to run processes
+  # @option options [Boolean] :keep_file_descriptors (false)    Inherit file descriptors
   #
   def initialize(options={})
     @options = options.dup
@@ -136,6 +137,7 @@ class Foreman::Engine
   # @param [Hash]   options
   #
   # @option options [Hash] :env  A custom environment for this process
+  # @option options [Boolean] :keep_file_descriptors  Inherit file descriptors
   #
   def register(name, command, options={})
     options[:env] ||= env
@@ -159,7 +161,7 @@ class Foreman::Engine
   def load_procfile(filename)
     options[:root] ||= File.dirname(filename)
     Foreman::Procfile.new(filename).entries do |name, command|
-      register name, command, :cwd => options[:root]
+      register name, command, :cwd => options[:root], :keep_file_descriptors => options[:keep_file_descriptors]
     end
     self
   end

--- a/lib/foreman/process.rb
+++ b/lib/foreman/process.rb
@@ -11,8 +11,9 @@ class Foreman::Process
   # @param [String] command  The command to run
   # @param [Hash]   options
   #
-  # @option options [String] :cwd (./)  Change to this working directory before executing the process
-  # @option options [Hash]   :env ({})  Environment variables to set for this process
+  # @option options [String]  :cwd                   (./)     Change to this working directory before executing the process
+  # @option options [Hash]    :env                   ({})     Environment variables to set for this process
+  # @option options [Boolean] :keep_file_descriptors (false)  Inherit file descriptors
   #
   def initialize(command, options={})
     @command = command
@@ -40,18 +41,20 @@ class Foreman::Process
   #
   # @param [Hash] options
   #
-  # @option options :env    ({})       Environment variables to set for this execution
-  # @option options :output ($stdout)  The output stream
+  # @option options :env                      ({})       Environment variables to set for this execution
+  # @option options :output                   ($stdout)  The output stream
+  # @option options :keep_file_descriptors    (false)    Keep file descriptors
   #
   # @returns [Fixnum] pid  The +pid+ of the process
   #
   def run(options={})
-    env    = @options[:env].merge(options[:env] || {})
-    output = options[:output] || $stdout
-    runner = "#{Foreman.runner}".shellescape
+    env                   = @options[:env].merge(options[:env] || {})
+    output                = options[:output] || $stdout
+    keep_file_descriptors = @options[:keep_file_descriptors] || options[:keep_file_descriptors]
+    runner                = "#{Foreman.runner}".shellescape
     
     Dir.chdir(cwd) do
-      Process.spawn env, expanded_command(env), :out => output, :err => output
+      Process.spawn env, expanded_command(env), :out => output, :err => output, :close_others => !keep_file_descriptors
     end
   end
 


### PR DESCRIPTION
`Process.spawn` closes file descriptors as default. 

As `bundler` has `--keep-file-descriptors` option, 

```
NAME
       bundle-exec - Execute a command in the context of the bundle

SYNOPSIS
       bundle exec [--keep-file-descriptors] command

DESCRIPTION
       This command executes the command, making all gems specified in the Gemfile(5) available to require in Ruby programs.

       Essentially,  if  you  would normally have run something like rspec spec/my_spec.rb, and you want to use the gems specified in the Gemfile(5) and installed via bundle
       install(1) bundle-install.1.html, you should run bundle exec rspec spec/my_spec.rb.

       Note that bundle exec does not require that an executable is available on your shell´s $PATH.

OPTIONS
       --keep-file-descriptors
              Exec in Ruby 2.0 began discarding non-standard file descriptors. When this flag is passed, exec will revert to the 1.9 behaviour of passing all  file  descrip-
              tors to the new process.
```

I added `--keep-file-descriptors` option to foreman.

This is useful and necessary for a situation like that the parent processes `listen(2)` a port, and pass its file descriptor to child processes to create a Socket opening the file descriptor to `accept(2)` as [Server::Starter](https://github.com/sonots/ruby-server-starter) does. 