### PR TITLE
Fix Procfile#[] to return nil for non-existing entries

### DIFF
--- a/lib/foreman/procfile.rb
+++ b/lib/foreman/procfile.rb
@@ -32,7 +32,9 @@ class Foreman::Procfile
   # @param [String] name  The name of the Procfile entry to retrieve
   #
   def [](name)
-    @entries.detect { |n,c| name == n }.last
+    if entry = @entries.detect { |n,c| name == n }
+      entry.last
+    end
   end
 
   # Create a +Procfile+ entry

--- a/spec/foreman/procfile_spec.rb
+++ b/spec/foreman/procfile_spec.rb
@@ -22,6 +22,12 @@ describe Foreman::Procfile, :fakefs do
     expect(procfile["foo_bar"]).to eq("./foo_bar")
   end
 
+  it "returns nil when attempting to retrieve an non-existing entry" do
+    write_procfile
+    procfile = Foreman::Procfile.new("Procfile")
+    expect(procfile["unicorn"]).to eq(nil)
+  end
+
   it "can have a process appended to it" do
     subject["charlie"] = "./charlie"
     expect(subject["charlie"]).to eq("./charlie")


### PR DESCRIPTION
This fixes the `Foreman::Procfile#[]` method to return `nil` when given the name of an entry that doesn't exist. I ran into this while using `Foreman::Procfile` to automate some stuff.

```
  1) Foreman::Procfile returns nil when attempting to retrieve an non-existing entry
     Failure/Error: expect(procfile["unicorn"]).to eq(nil)
     NoMethodError:
       undefined method `last' for nil:NilClass
     # ./lib/foreman/procfile.rb:35:in `[]'
     # ./spec/foreman/procfile_spec.rb:28:in `block (2 levels) in <top (required)>'
``` 

/cc @ddollar