### PR TITLE
allow export to be used in .env files

### DIFF
--- a/lib/foreman/env.rb
+++ b/lib/foreman/env.rb
@@ -6,7 +6,7 @@ class Foreman::Env
 
   def initialize(filename)
     @entries = File.read(filename).gsub("\r\n","\n").split("\n").inject({}) do |ax, line|
-      if line =~ /\A([A-Za-z_0-9]+)=(.*)\z/
+      if line =~ /\A(?:export\s+)?([A-Za-z_0-9]+)=(.*)\z/
         key = $1
         case val = $2
           # Remove single quotes

--- a/spec/foreman/engine_spec.rb
+++ b/spec/foreman/engine_spec.rb
@@ -107,6 +107,16 @@ describe "Foreman::Engine", :fakefs do
       subject.load_env "/tmp/env"
       expect(subject.send(:base_port)).to eq(9000)
     end
+
+    it "should handle lines beginning with export" do
+      File.open("/tmp/env", "w") do |f|
+        f.puts 'export FOO=bar'
+        f.puts 'export BAZ="qux"'
+      end
+      subject.load_env "/tmp/env"
+      expect(subject.env["FOO"]).to   eq("bar")
+      expect(subject.env["BAZ"]).to   eq("qux")
+    end
   end
 
 end


### PR DESCRIPTION
When removing Dotenv as dependency there was a small regression. Dotenv handles files where the environment variables are preceeded by 'export'.

I don't know this functionality was intentionally dropped but with this commit it would be available again.

Thanks for the great tool.