### PR TITLE
Propagate process failure

### DIFF
--- a/lib/foreman/engine.rb
+++ b/lib/foreman/engine.rb
@@ -59,6 +59,7 @@ class Foreman::Engine
     sleep 0.1
     watch_for_termination { terminate_gracefully }
     shutdown
+    exit(@exitstatus) if @exitstatus
   end
 
   # Set up deferred signal handlers
@@ -412,6 +413,7 @@ private
 
   def watch_for_termination
     pid, status = Process.wait2
+    @exitstatus ||= status.exitstatus
     output_with_mutex name_for(pid), termination_message_for(status)
     @running.delete(pid)
     yield if block_given?

--- a/spec/foreman/cli_spec.rb
+++ b/spec/foreman/cli_spec.rb
@@ -51,6 +51,11 @@ describe "Foreman::CLI", :fakefs do
           expect(output).to match(/ps.1   \| PS env var is ps.1/)
         end
       end
+
+      it "fails if process fails" do
+        output = `bundle exec foreman start -f #{resource_path "Procfile.bad"} && echo success`
+        expect(output).not_to include 'success'
+      end
     end
   end
 

--- a/spec/resources/Procfile.bad
+++ b/spec/resources/Procfile.bad
@@ -1,0 +1,2 @@
+good: sleep 1
+bad: false


### PR DESCRIPTION
**Problem description**

Consider `Procfile` like this:
```
faye: bin/rackup faye.ru
rspec: bin/rspec spec
```
When `rspec` process finishes and fails it would be nice to have it's exit code returned by `foreman`.
That way it would be much easier to configure CI environments.