### PR TITLE
Document $PORT and $PS

### DIFF
--- a/man/foreman.1.ronn
+++ b/man/foreman.1.ronn
@@ -159,6 +159,11 @@ You can validate your Procfile format using the `check` command:
 
     $ foreman check
 
+The special environment variables `$PORT` and `$PS` are available within the
+Procfile. `$PORT` starts as the base port as specified with `-p` above and
+increments by 100 for each new process line. `$PS` is the name of the process
+for the line.
+
 ## ENVIRONMENT
 
 If a `.env` file exists in the current directory, the default environment will

--- a/man/foreman.1.ronn
+++ b/man/foreman.1.ronn
@@ -160,9 +160,12 @@ You can validate your Procfile format using the `check` command:
     $ foreman check
 
 The special environment variables `$PORT` and `$PS` are available within the
-Procfile. `$PORT` starts as the base port as specified with `-p` above and
-increments by 100 for each new process line. `$PS` is the name of the process
-for the line.
+Procfile. `$PORT` is the port selected for that process. `$PS` is the name of
+the process for the line.
+
+The `$PORT` value starts as the base port as specified by `-p`, then increments
+by 100 for each new process line. Multiple instances of the same process are
+assigned `$PORT` values that increment by 1.
 
 ## ENVIRONMENT
 


### PR DESCRIPTION
Update the ronn documentation to explain that $PORT and $PS exist and
that $PORT starts as the base port number and is incremented on each
line.