### PR TITLE
remove win32console dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,10 +2,6 @@ source "http://rubygems.org"
 
 gemspec
 
-platform :mingw do
-  gem "win32console", "~> 1.3.0"
-end
-
 group :test do
   gem 'rake'
   gem 'fakefs', '~> 0.3.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,7 +44,6 @@ GEM
     simplecov-html (0.8.0)
     thor (0.19.1)
     timecop (0.7.1)
-    win32console (1.3.2-x86-mingw32)
     xml-simple (1.1.3)
     yard (0.8.7.4)
 
@@ -64,5 +63,4 @@ DEPENDENCIES
   rspec (~> 2.99.0)
   simplecov
   timecop
-  win32console (~> 1.3.0)
   yard

--- a/foreman.gemspec
+++ b/foreman.gemspec
@@ -18,9 +18,4 @@ Gem::Specification.new do |gem|
   gem.files << "man/foreman.1"
 
   gem.add_dependency 'thor', '~> 0.19.1'
-
-  if ENV["PLATFORM"] == "mingw32"
-    gem.add_dependency "win32console", "~> 1.3.0"
-    gem.platform = Gem::Platform.new("mingw32")
-  end
 end


### PR DESCRIPTION
Since b1d5742, win32console is not used.