### PR TITLE
Allow supervisord environment vars to have "="

### DIFF
--- a/data/export/supervisord/app.conf.erb
+++ b/data/export/supervisord/app.conf.erb
@@ -5,7 +5,11 @@ engine.each_process do |name, process|
     port = engine.port_for(process, num)
     full_name = "#{app}-#{name}-#{num}"
     environment = engine.env.merge("PORT" => port.to_s).map do |key, value|
-      "#{key}=\"#{shell_quote(value)}\""
+    	value = shell_quote(value)
+    	value = value.gsub('\=', '=')
+    	value = value.gsub('\&', '&')
+    	value = value.gsub('\?', '?')
+      "#{key}=\"#{value}\""
     end
     app_names << full_name
 -%>

--- a/spec/foreman/engine_spec.rb
+++ b/spec/foreman/engine_spec.rb
@@ -82,12 +82,14 @@ describe "Foreman::Engine", :fakefs do
         f.puts 'BAZ="qux"'
         f.puts "FRED='barney'"
         f.puts 'OTHER="escaped\"quote"'
+        f.puts 'URL="http://example.com/api?foo=bar&baz=1"'
       end
       subject.load_env "/tmp/env"
       expect(subject.env["FOO"]).to   eq("bar")
       expect(subject.env["BAZ"]).to   eq("qux")
       expect(subject.env["FRED"]).to  eq("barney")
       expect(subject.env["OTHER"]).to eq('escaped"quote')
+      expect(subject.env["URL"]).to   eq("http://example.com/api?foo=bar&baz=1")
     end
 
     it "should handle multiline strings" do

--- a/spec/foreman/export/supervisord_spec.rb
+++ b/spec/foreman/export/supervisord_spec.rb
@@ -14,6 +14,8 @@ describe Foreman::Export::Supervisord, :fakefs do
   before(:each) { stub(supervisord).say }
 
   it "exports to the filesystem" do
+    write_env(".env", "FOO"=>"bar", "URL"=>"http://example.com/api?foo=bar&baz=1")
+    supervisord.engine.load_env('.env')
     supervisord.export
     expect(File.read("/tmp/init/app.conf")).to eq(example_export_file("supervisord/app-alpha-1.conf"))
   end

--- a/spec/resources/export/supervisord/app-alpha-1.conf
+++ b/spec/resources/export/supervisord/app-alpha-1.conf
@@ -7,7 +7,7 @@ stdout_logfile=/var/log/app/alpha-1.log
 stderr_logfile=/var/log/app/alpha-1.error.log
 user=app
 directory=/tmp/app
-environment=PORT="5000"
+environment=FOO="bar",URL="http://example.com/api?foo=bar&baz=1",PORT="5000"
 
 [program:app-bravo-1]
 command=./bravo
@@ -18,7 +18,7 @@ stdout_logfile=/var/log/app/bravo-1.log
 stderr_logfile=/var/log/app/bravo-1.error.log
 user=app
 directory=/tmp/app
-environment=PORT="5100"
+environment=FOO="bar",URL="http://example.com/api?foo=bar&baz=1",PORT="5100"
 
 [program:app-foo_bar-1]
 command=./foo_bar
@@ -29,7 +29,7 @@ stdout_logfile=/var/log/app/foo_bar-1.log
 stderr_logfile=/var/log/app/foo_bar-1.error.log
 user=app
 directory=/tmp/app
-environment=PORT="5200"
+environment=FOO="bar",URL="http://example.com/api?foo=bar&baz=1",PORT="5200"
 
 [program:app-foo-bar-1]
 command=./foo-bar
@@ -40,7 +40,7 @@ stdout_logfile=/var/log/app/foo-bar-1.log
 stderr_logfile=/var/log/app/foo-bar-1.error.log
 user=app
 directory=/tmp/app
-environment=PORT="5300"
+environment=FOO="bar",URL="http://example.com/api?foo=bar&baz=1",PORT="5300"
 
 [group:app]
 programs=app-alpha-1,app-bravo-1,app-foo_bar-1,app-foo-bar-1


### PR DESCRIPTION
Prior to this PR, an environment variable configured for use with Foreman could not contain a `?`, `=` or `&` (common in URLs) if the target configuration was set to SupervisorD. This PR cleans up the output from `Shellwords.escape` in order to be ready for use in a `app*.conf` file. I've updated the tests to cover this particular issue.

---

From [the documentation for Shellwords](http://ruby-doc.org/stdlib-1.9.3/libdoc/shellwords/rdoc/Shellwords.html#method-c-shellescape)

>Note that a resulted string should be used unquoted and is not intended for use in double quotes nor in single quotes.

---

From [the documentation for SupervisorD](http://supervisord.org/configuration.html#program-x-section-settings)

>A list of key/value pairs in the form `KEY="val",KEY2="val2"` that will be placed in the child process’ environment. The environment string may contain Python string expressions that will be evaluated against a dictionary containing `group_name`, `host_node_name`, `process_num`, program_name, and `here` (the directory of the supervisord config file). Values containing non-alphanumeric characters should be quoted (e.g. `KEY="val:123",KEY2="val,456"`). Otherwise, quoting the values is optional but recommended. Note that the subprocess will inherit the environment variables of the shell used to start “supervisord” except for the ones overridden here. 

Fixes #571
Fixes #519

/cc @inbeom, @ddollar