### PR TITLE
Fix no process output on Windows, caused by read_nonblock throwing EWOULDBLOCK

### DIFF
--- a/lib/foreman/engine.rb
+++ b/lib/foreman/engine.rb
@@ -371,7 +371,7 @@ private
 
   def read_self_pipe
     @selfpipe[:reader].read_nonblock(11)
-  rescue Errno::EAGAIN, Errno::EINTR, Errno::EBADF
+  rescue Errno::EAGAIN, Errno::EINTR, Errno::EBADF, Errno::EWOULDBLOCK
     # ignore
   end
 


### PR DESCRIPTION
Windows does not support non-blocking read on pipes - which causes read_noblock
to throw Errno::EWOULDBLOCK, which is not handled in resque block.

Fixes #575