### PR TITLE
Added possible fix for pkg install on El Capitan.

### DIFF
--- a/dist/resources/pkg/postinstall
+++ b/dist/resources/pkg/postinstall
@@ -1,2 +1,2 @@
 #!/bin/sh
-ln -sf /usr/local/foreman/bin/foreman /usr/bin/foreman
+ln -sf /usr/local/foreman/bin/foreman /usr/local/bin/foreman


### PR DESCRIPTION
El Capitan is the first version of OS X to not have root, and locations that are not writable, one of which is `/usr/bin`. The previous version of the foreman installation package relied upon the fact that this was
writeable, and thus it failed on the new version of the OS.

This PR should, in theory, fix this issue, but I found no way to build the pkg myself.