### PR TITLE
Strip non-quoted whitespace

### DIFF
--- a/lib/foreman/env.rb
+++ b/lib/foreman/env.rb
@@ -8,7 +8,7 @@ class Foreman::Env
     @entries = File.read(filename).gsub("\r\n","\n").split("\n").inject({}) do |ax, line|
       if line =~ /\A([A-Za-z_0-9]+)=(.*)\z/
         key = $1
-        case val = $2
+        case val = $2.rstrip
           # Remove single quotes
           when /\A'(.*)'\z/ then ax[key] = $1
           # Remove double quotes and unescape string preserving newline characters


### PR DESCRIPTION
Currently Foreman does not strip whitespace in .env. Which means that  `URL=www.google.com`  will work whereas - 

```
URL=www.google.com   
```  
will not work.  Also consider 
```
curl www.google.com   
``` 
(which works) vs  `curl "www.google.com      "`. 

Both Bash and Fish shell strip non-quoted whitespace when setting Environmental Variables so it would make sense to match their conventions in this regard. 