### PR TITLE
Remove obsolete warning from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ Manage Procfile-based applications
 
     $ gem install foreman
 
+Or add `gem 'foreman'` to your Gemfile and run:
+
+    $ bundle install
+
 ## Getting Started
 
 * http://blog.daviddollar.org/2011/05/06/introducing-foreman.html

--- a/README.md
+++ b/README.md
@@ -25,7 +25,15 @@ Manage Procfile-based applications
 
     $ gem install foreman
 
-Or add `gem 'foreman'` to your Gemfile and run:
+Or add foreman to your Gemfile:
+
+```
+group :development do
+  gem 'foreman', require: false
+end
+```
+
+and then run:
 
     $ bundle install
 

--- a/README.md
+++ b/README.md
@@ -25,8 +25,6 @@ Manage Procfile-based applications
 
     $ gem install foreman
 
-Ruby users should take care *not* to install foreman in their project's `Gemfile`.
-
 ## Getting Started
 
 * http://blog.daviddollar.org/2011/05/06/introducing-foreman.html


### PR DESCRIPTION
Based on https://github.com/ddollar/foreman/issues/573, it appears that this message is no longer needed. By removing it, we prevent future potential confusion.