### PR TITLE
handle nil exitstatus

### DIFF
--- a/lib/foreman/cli.rb
+++ b/lib/foreman/cli.rb
@@ -101,7 +101,7 @@ class Foreman::CLI < Thor
       Process.kill(:INT, pid)
     end
     Process.wait(pid)
-    exit $?.exitstatus
+    exit ( $?.exitstatus ? $?.exitstatus : 1 )  # in some cases, $?.exitstatus can be nil
   rescue Interrupt
   end
 


### PR DESCRIPTION
This should fix #603.  When using Ctrl-C to end an app run by foreman, it is possible for `$?.exitstatus` to be `nil`.  This PR defaults foreman's exit code to `1` in that case, which avoids output of a cryptic stacktrace.