### PR TITLE
Fix immediate exiting of master target

### DIFF
--- a/data/export/systemd/master.target.erb
+++ b/data/export/systemd/master.target.erb
@@ -1,5 +1,4 @@
 [Unit]
-StopWhenUnneeded=true
 Wants=<%= process_master_names.join(' ') %>
 
 [Install]

--- a/data/export/systemd/process.service.erb
+++ b/data/export/systemd/process.service.erb
@@ -1,5 +1,5 @@
 [Unit]
-PartOf=<% app %>-<% name %>.target
+PartOf=<%= app %>-<%= name %>.target
 
 [Service]
 User=<%= user %>

--- a/data/export/systemd/process.service.erb
+++ b/data/export/systemd/process.service.erb
@@ -1,5 +1,5 @@
 [Unit]
-StopWhenUnneeded=true
+PartOf=<% app %>-<% name %>.target
 
 [Service]
 User=<%= user %>

--- a/data/export/systemd/process_master.target.erb
+++ b/data/export/systemd/process_master.target.erb
@@ -1,3 +1,3 @@
 [Unit]
-PartOf= <%= app %>.target
+PartOf=<%= app %>.target
 Wants=<%= process_names.join(' ') %>

--- a/data/export/systemd/process_master.target.erb
+++ b/data/export/systemd/process_master.target.erb
@@ -1,3 +1,3 @@
 [Unit]
-StopWhenUnneeded=true
+PartOf= <%= app %>.target
 Wants=<%= process_names.join(' ') %>

--- a/spec/resources/export/systemd/concurrency/app-alpha-1.service
+++ b/spec/resources/export/systemd/concurrency/app-alpha-1.service
@@ -1,5 +1,5 @@
 [Unit]
-StopWhenUnneeded=true
+PartOf=app-alpha.target
 
 [Service]
 User=app

--- a/spec/resources/export/systemd/concurrency/app-alpha-2.service
+++ b/spec/resources/export/systemd/concurrency/app-alpha-2.service
@@ -1,5 +1,5 @@
 [Unit]
-StopWhenUnneeded=true
+PartOf=app-alpha.target
 
 [Service]
 User=app

--- a/spec/resources/export/systemd/concurrency/app-alpha.target
+++ b/spec/resources/export/systemd/concurrency/app-alpha.target
@@ -1,3 +1,3 @@
 [Unit]
-StopWhenUnneeded=true
+PartOf=app.target
 Wants=app-alpha-1.service app-alpha-2.service

--- a/spec/resources/export/systemd/concurrency/app.target
+++ b/spec/resources/export/systemd/concurrency/app.target
@@ -1,5 +1,4 @@
 [Unit]
-StopWhenUnneeded=true
 Wants=app-alpha.target
 
 [Install]

--- a/spec/resources/export/systemd/standard/app-alpha-1.service
+++ b/spec/resources/export/systemd/standard/app-alpha-1.service
@@ -1,5 +1,5 @@
 [Unit]
-StopWhenUnneeded=true
+PartOf=app-alpha.target
 
 [Service]
 User=app

--- a/spec/resources/export/systemd/standard/app-alpha.target
+++ b/spec/resources/export/systemd/standard/app-alpha.target
@@ -1,3 +1,3 @@
 [Unit]
-StopWhenUnneeded=true
+PartOf=app.target
 Wants=app-alpha-1.service

--- a/spec/resources/export/systemd/standard/app-bravo-1.service
+++ b/spec/resources/export/systemd/standard/app-bravo-1.service
@@ -1,5 +1,5 @@
 [Unit]
-StopWhenUnneeded=true
+PartOf=app-bravo.target
 
 [Service]
 User=app

--- a/spec/resources/export/systemd/standard/app-bravo.target
+++ b/spec/resources/export/systemd/standard/app-bravo.target
@@ -1,3 +1,3 @@
 [Unit]
-StopWhenUnneeded=true
+PartOf=app.target
 Wants=app-bravo-1.service

--- a/spec/resources/export/systemd/standard/app.target
+++ b/spec/resources/export/systemd/standard/app.target
@@ -1,5 +1,4 @@
 [Unit]
-StopWhenUnneeded=true
 Wants=app-alpha.target app-bravo.target app-foo_bar.target app-foo-bar.target
 
 [Install]


### PR DESCRIPTION
Since [this issue](https://github.com/ddollar/foreman/issues/591) hasn't been commented on, I propose to bring these changes in. I'm not a systemd expert, but I don't think my code is creating any additional bugs. If it's not perfect, it can still be improved upon later. Meanwhile, this fixes the issue with services immediately stopping after start unless enabled.