### PR TITLE
update for foreman exitstatus on sinatra

### DIFF
--- a/lib/foreman/engine.rb
+++ b/lib/foreman/engine.rb
@@ -439,7 +439,7 @@ private
       return nil
     end
 
-    @exitstatus ||= status.exitstatus
+    @exitstatus ||= status.exitstatus if !status.nil?
 
     # If no childred have died, nothing to do here
     return nil unless pid


### PR DESCRIPTION
this fixes a problem where sinatra apps do start up with the following error:
`check_for_termination': undefined method `exitstatus' for nil:NilClass

