### PR TITLE
Allow custom instance identifiers

### DIFF
--- a/data/export/bluepill/master.pill.erb
+++ b/data/export/bluepill/master.pill.erb
@@ -5,13 +5,12 @@ Bluepill.application("<%= app %>", :foreground => false, :log_file => "/var/log/
 
 <% engine.each_process do |name, process| %>
 <% 1.upto(engine.formation[name]) do |num| %>
-  <% port = engine.port_for(process, num) %>
   app.process("<%= name %>-<%= num %>") do |process|
     process.start_command = %Q{<%= process.command %>}
 
     process.working_dir = "<%= engine.root %>"
     process.daemonize = true
-    process.environment = <%= engine.env.merge("PORT" => port.to_s).inspect %>
+    process.environment = <%= engine.env_for(process, num).inspect %>
     process.stop_signals = [:quit, 30.seconds, :term, 5.seconds, :kill]
     process.stop_grace_time = 45.seconds
 

--- a/data/export/daemon/process.conf.erb
+++ b/data/export/daemon/process.conf.erb
@@ -2,7 +2,7 @@ start on starting <%= app %>-<%= name.gsub('_', '-') %>
 stop on stopping <%= app %>-<%= name.gsub('_', '-') %>
 respawn
 
-env PORT=<%= port %><% engine.env.each_pair do |var, env| %>
+<% env.each_pair do |var, env| %>
 env <%= var.upcase %>=<%= env %><% end %>
 
 exec start-stop-daemon --start --chuid <%= user %> --chdir <%= engine.root %> --make-pidfile --pidfile <%= run %>/<%= app %>-<%= name %>-<%= num %>.pid --exec <%= executable %><%= arguments %> >> <%= log %>/<%= app %>-<%= name %>-<%= num %>.log 2>&1

--- a/data/export/launchd/launchd.plist.erb
+++ b/data/export/launchd/launchd.plist.erb
@@ -6,7 +6,7 @@
     <string><%= "#{app}-#{name}-#{num}" %></string>
     <key>EnvironmentVariables</key>
     <dict>
-    <%- engine.env.merge("PORT" => port).each_pair do |var,env| -%>
+    <%- env.each_pair do |var,env| -%>
         <key><%= var.upcase %></key>
         <string><%= env %></string>
     <%- end -%>

--- a/data/export/supervisord/app.conf.erb
+++ b/data/export/supervisord/app.conf.erb
@@ -2,9 +2,8 @@
 app_names = []
 engine.each_process do |name, process|
   1.upto(engine.formation[name]) do |num|
-    port = engine.port_for(process, num)
     full_name = "#{app}-#{name}-#{num}"
-    environment = engine.env.merge("PORT" => port.to_s).map do |key, value|
+    environment = engine.env_for(process, num).map do |key, value|
     	value = shell_quote(value)
     	value = value.gsub('\=', '=')
     	value = value.gsub('\&', '&')

--- a/data/export/systemd/process.service.erb
+++ b/data/export/systemd/process.service.erb
@@ -4,6 +4,7 @@ PartOf=<%= app %>-<%= name %>.target
 [Service]
 User=<%= user %>
 WorkingDirectory=<%= engine.root %>
+Environment=INSTANCE_NAME=%i
 Environment=PORT=%i<% engine.env.each_pair do |var,env| %>
 Environment=<%= var.upcase %>=<%= env %><% end %>
 ExecStart=/bin/bash -lc '<%= process.command %>'

--- a/data/export/upstart/process.conf.erb
+++ b/data/export/upstart/process.conf.erb
@@ -2,8 +2,7 @@ start on starting <%= app %>-<%= name %>
 stop on stopping <%= app %>-<%= name %>
 respawn
 
-env PORT=<%= port %>
-<% engine.env.each do |name,value| -%>
+<% env.each do |name,value| -%>
 env <%= name.upcase %>='<%= value.gsub(/'/, "'\"'\"'") %>'
 <% end -%>
 

--- a/lib/foreman/export/daemon.rb
+++ b/lib/foreman/export/daemon.rb
@@ -17,7 +17,7 @@ class Foreman::Export::Daemon < Foreman::Export::Base
       write_template "daemon/process_master.conf.erb", "#{app}-#{name}.conf", binding
 
       1.upto(engine.formation[name]) do |num|
-        port = engine.port_for(process, num)
+        env = engine.env_for(process, num)
         arguments = process.command.split(" ")
         executable = arguments.slice!(0)
         arguments = arguments.size > 0 ? " -- #{arguments.join(' ')}" : ""

--- a/lib/foreman/export/inittab.rb
+++ b/lib/foreman/export/inittab.rb
@@ -12,7 +12,7 @@ class Foreman::Export::Inittab < Foreman::Export::Base
     engine.each_process do |name, process|
       1.upto(engine.formation[name]) do |num|
         id = app.slice(0, 2).upcase + sprintf("%02d", index)
-        port = engine.port_for(process, num)
+        port = engine.instance_name_for(process, num)
 
         commands = []
         commands << "cd #{engine.root}"

--- a/lib/foreman/export/launchd.rb
+++ b/lib/foreman/export/launchd.rb
@@ -7,7 +7,7 @@ class Foreman::Export::Launchd < Foreman::Export::Base
     super
     engine.each_process do |name, process|
       1.upto(engine.formation[name]) do |num|
-        port = engine.port_for(process, num)
+        env = engine.env_for(process, num)
         command_args = process.command.split(/\s+/).map{|arg|
           case arg
           when "$PORT" then port

--- a/lib/foreman/export/runit.rb
+++ b/lib/foreman/export/runit.rb
@@ -19,8 +19,7 @@ class Foreman::Export::Runit < Foreman::Export::Base
         write_template "runit/run.erb", "#{process_directory}/run", binding
         chmod 0755, "#{process_directory}/run"
 
-        port = engine.port_for(process, num)
-        engine.env.merge("PORT" => port.to_s).each do |key, value|
+        engine.env_for(process, num).each do |key, value|
           write_file "#{process_directory}/env/#{key}", value
         end
 

--- a/lib/foreman/export/systemd.rb
+++ b/lib/foreman/export/systemd.rb
@@ -25,7 +25,7 @@ class Foreman::Export::Systemd < Foreman::Export::Base
 
       create_directory("#{app}-#{name}.target.wants")
       1.upto(engine.formation[name])
-        .collect { |num| engine.port_for(process, num) }
+        .collect { |num| engine.instance_name_for(process, num) }
         .collect { |port| "#{app}-#{name}@#{port}.service" }
         .each do |process_name|
         create_symlink("#{app}-#{name}.target.wants/#{process_name}", "../#{service_fn}") rescue Errno::EEXIST # This is needed because rr-mocks do not call the origial cleanup

--- a/lib/foreman/export/upstart.rb
+++ b/lib/foreman/export/upstart.rb
@@ -19,7 +19,7 @@ class Foreman::Export::Upstart < Foreman::Export::Base
       write_template process_master_template, process_master_file, binding
 
       1.upto(engine.formation[name]) do |num|
-        port = engine.port_for(process, num)
+        env = engine.env_for(process, num)
         process_file = "#{app}-#{name}-#{num}.conf"
         clean File.join(location, process_file)
         write_template process_template, process_file, binding

--- a/lib/foreman/instance_name_generators/tcp_udp_port_generator.rb
+++ b/lib/foreman/instance_name_generators/tcp_udp_port_generator.rb
@@ -1,0 +1,28 @@
+require 'foreman'
+
+module Foreman::InstanceNameGenerators
+  class TCPUDPPortGenerator
+    attr_accessor :engine, :base_port, :generator_idx
+
+    # Create a TCP/UDP port number generator
+    #
+    # @param [Foreman::Engine]  engine        The +Engine+ using this generator
+    # @param [Fixnum]           generator_idx The index of all generators of the same class (Counting from 1)
+    #
+    def initialize(engine, generator_idx)
+      @engine        = engine
+      @generator_idx = generator_idx.to_int
+      @base_port     = (engine.options[:port] || engine.env["PORT"] || ENV["PORT"] || 5000).to_int
+    end
+
+    # Get the port for a given instance
+    #
+    # @param [Fixnum]           instance_idx  The instance index of the process (Counting from 1)
+    #
+    # @returns [Fixnum]         The port to use for this instance of this process
+    #
+    def [](instance_idx)
+      base_port + (generator_idx * 100) + (instance_idx -1)
+    end
+  end
+end

--- a/spec/resources/export/bluepill/app-concurrency.pill
+++ b/spec/resources/export/bluepill/app-concurrency.pill
@@ -11,7 +11,7 @@ Bluepill.application("app", :foreground => false, :log_file => "/var/log/bluepil
 
     process.working_dir = "/tmp/app"
     process.daemonize = true
-    process.environment = {"PORT"=>"5000"}
+    process.environment = {"INSTANCE_NAME"=>"5000", "PS"=>"alpha.1", "PORT"=>"5000"}
     process.stop_signals = [:quit, 30.seconds, :term, 5.seconds, :kill]
     process.stop_grace_time = 45.seconds
 
@@ -30,7 +30,7 @@ Bluepill.application("app", :foreground => false, :log_file => "/var/log/bluepil
 
     process.working_dir = "/tmp/app"
     process.daemonize = true
-    process.environment = {"PORT"=>"5001"}
+    process.environment = {"INSTANCE_NAME"=>"5001", "PS"=>"alpha.2", "PORT"=>"5001"}
     process.stop_signals = [:quit, 30.seconds, :term, 5.seconds, :kill]
     process.stop_grace_time = 45.seconds
 

--- a/spec/resources/export/bluepill/app.pill
+++ b/spec/resources/export/bluepill/app.pill
@@ -11,7 +11,7 @@ Bluepill.application("app", :foreground => false, :log_file => "/var/log/bluepil
 
     process.working_dir = "/tmp/app"
     process.daemonize = true
-    process.environment = {"PORT"=>"5000"}
+    process.environment = {"INSTANCE_NAME"=>"5000", "PS"=>"alpha.1", "PORT"=>"5000"}
     process.stop_signals = [:quit, 30.seconds, :term, 5.seconds, :kill]
     process.stop_grace_time = 45.seconds
 
@@ -29,7 +29,7 @@ Bluepill.application("app", :foreground => false, :log_file => "/var/log/bluepil
 
     process.working_dir = "/tmp/app"
     process.daemonize = true
-    process.environment = {"PORT"=>"5100"}
+    process.environment = {"INSTANCE_NAME"=>"5100", "PS"=>"bravo.1", "PORT"=>"5100"}
     process.stop_signals = [:quit, 30.seconds, :term, 5.seconds, :kill]
     process.stop_grace_time = 45.seconds
 
@@ -47,7 +47,7 @@ Bluepill.application("app", :foreground => false, :log_file => "/var/log/bluepil
 
     process.working_dir = "/tmp/app"
     process.daemonize = true
-    process.environment = {"PORT"=>"5200"}
+    process.environment = {"INSTANCE_NAME"=>"5200", "PS"=>"foo_bar.1", "PORT"=>"5200"}
     process.stop_signals = [:quit, 30.seconds, :term, 5.seconds, :kill]
     process.stop_grace_time = 45.seconds
 
@@ -65,7 +65,7 @@ Bluepill.application("app", :foreground => false, :log_file => "/var/log/bluepil
 
     process.working_dir = "/tmp/app"
     process.daemonize = true
-    process.environment = {"PORT"=>"5300"}
+    process.environment = {"INSTANCE_NAME"=>"5300", "PS"=>"foo-bar.1", "PORT"=>"5300"}
     process.stop_signals = [:quit, 30.seconds, :term, 5.seconds, :kill]
     process.stop_grace_time = 45.seconds
 

--- a/spec/resources/export/daemon/app-alpha-1.conf
+++ b/spec/resources/export/daemon/app-alpha-1.conf
@@ -2,6 +2,9 @@ start on starting app-alpha
 stop on stopping app-alpha
 respawn
 
+
+env INSTANCE_NAME=5000
+env PS=alpha.1
 env PORT=5000
 
 exec start-stop-daemon --start --chuid app --chdir /tmp/app --make-pidfile --pidfile /var/run/app/app-alpha-1.pid --exec ./alpha >> /var/log/app/app-alpha-1.log 2>&1

--- a/spec/resources/export/daemon/app-alpha-2.conf
+++ b/spec/resources/export/daemon/app-alpha-2.conf
@@ -2,6 +2,9 @@ start on starting app-alpha
 stop on stopping app-alpha
 respawn
 
+
+env INSTANCE_NAME=5001
+env PS=alpha.2
 env PORT=5001
 
 exec start-stop-daemon --start --chuid app --chdir /tmp/app --make-pidfile --pidfile /var/run/app/app-alpha-2.pid --exec ./alpha >> /var/log/app/app-alpha-2.log 2>&1

--- a/spec/resources/export/daemon/app-bravo-1.conf
+++ b/spec/resources/export/daemon/app-bravo-1.conf
@@ -2,6 +2,9 @@ start on starting app-bravo
 stop on stopping app-bravo
 respawn
 
+
+env INSTANCE_NAME=5100
+env PS=bravo.1
 env PORT=5100
 
 exec start-stop-daemon --start --chuid app --chdir /tmp/app --make-pidfile --pidfile /var/run/app/app-bravo-1.pid --exec ./bravo >> /var/log/app/app-bravo-1.log 2>&1

--- a/spec/resources/export/launchd/launchd-a.default
+++ b/spec/resources/export/launchd/launchd-a.default
@@ -6,6 +6,10 @@
     <string>app-alpha-1</string>
     <key>EnvironmentVariables</key>
     <dict>
+        <key>INSTANCE_NAME</key>
+        <string>5000</string>
+        <key>PS</key>
+        <string>alpha.1</string>
         <key>PORT</key>
         <string>5000</string>
     </dict>

--- a/spec/resources/export/launchd/launchd-b.default
+++ b/spec/resources/export/launchd/launchd-b.default
@@ -6,6 +6,10 @@
     <string>app-bravo-1</string>
     <key>EnvironmentVariables</key>
     <dict>
+        <key>INSTANCE_NAME</key>
+        <string>5100</string>
+        <key>PS</key>
+        <string>bravo.1</string>
         <key>PORT</key>
         <string>5100</string>
     </dict>

--- a/spec/resources/export/launchd/launchd-c.default
+++ b/spec/resources/export/launchd/launchd-c.default
@@ -6,6 +6,10 @@
     <string>app-alpha-1</string>
     <key>EnvironmentVariables</key>
     <dict>
+        <key>INSTANCE_NAME</key>
+        <string>5000</string>
+        <key>PS</key>
+        <string>alpha.1</string>
         <key>PORT</key>
         <string>5000</string>
     </dict>

--- a/spec/resources/export/supervisord/app-alpha-1.conf
+++ b/spec/resources/export/supervisord/app-alpha-1.conf
@@ -7,7 +7,7 @@ stdout_logfile=/var/log/app/alpha-1.log
 stderr_logfile=/var/log/app/alpha-1.error.log
 user=app
 directory=/tmp/app
-environment=FOO="bar",URL="http://example.com/api?foo=bar&baz=1",PORT="5000"
+environment=FOO="bar",URL="http://example.com/api?foo=bar&baz=1",INSTANCE_NAME="5000",PS="alpha.1",PORT="5000"
 
 [program:app-bravo-1]
 command=./bravo
@@ -18,7 +18,7 @@ stdout_logfile=/var/log/app/bravo-1.log
 stderr_logfile=/var/log/app/bravo-1.error.log
 user=app
 directory=/tmp/app
-environment=FOO="bar",URL="http://example.com/api?foo=bar&baz=1",PORT="5100"
+environment=FOO="bar",URL="http://example.com/api?foo=bar&baz=1",INSTANCE_NAME="5100",PS="bravo.1",PORT="5100"
 
 [program:app-foo_bar-1]
 command=./foo_bar
@@ -29,7 +29,7 @@ stdout_logfile=/var/log/app/foo_bar-1.log
 stderr_logfile=/var/log/app/foo_bar-1.error.log
 user=app
 directory=/tmp/app
-environment=FOO="bar",URL="http://example.com/api?foo=bar&baz=1",PORT="5200"
+environment=FOO="bar",URL="http://example.com/api?foo=bar&baz=1",INSTANCE_NAME="5200",PS="foo_bar.1",PORT="5200"
 
 [program:app-foo-bar-1]
 command=./foo-bar
@@ -40,7 +40,7 @@ stdout_logfile=/var/log/app/foo-bar-1.log
 stderr_logfile=/var/log/app/foo-bar-1.error.log
 user=app
 directory=/tmp/app
-environment=FOO="bar",URL="http://example.com/api?foo=bar&baz=1",PORT="5300"
+environment=FOO="bar",URL="http://example.com/api?foo=bar&baz=1",INSTANCE_NAME="5300",PS="foo-bar.1",PORT="5300"
 
 [group:app]
 programs=app-alpha-1,app-bravo-1,app-foo_bar-1,app-foo-bar-1

--- a/spec/resources/export/supervisord/app-alpha-2.conf
+++ b/spec/resources/export/supervisord/app-alpha-2.conf
@@ -7,7 +7,7 @@ stdout_logfile=/var/log/app/alpha-1.log
 stderr_logfile=/var/log/app/alpha-1.error.log
 user=app
 directory=/tmp/app
-environment=PORT="5000"
+environment=INSTANCE_NAME="5000",PS="alpha.1",PORT="5000"
 
 [program:app-alpha-2]
 command=./alpha
@@ -18,7 +18,7 @@ stdout_logfile=/var/log/app/alpha-2.log
 stderr_logfile=/var/log/app/alpha-2.error.log
 user=app
 directory=/tmp/app
-environment=PORT="5001"
+environment=INSTANCE_NAME="5001",PS="alpha.2",PORT="5001"
 
 [group:app]
 programs=app-alpha-1,app-alpha-2

--- a/spec/resources/export/systemd/app-alpha@.service
+++ b/spec/resources/export/systemd/app-alpha@.service
@@ -4,6 +4,7 @@ PartOf=app-alpha.target
 [Service]
 User=app
 WorkingDirectory=/tmp/app
+Environment=INSTANCE_NAME=%i
 Environment=PORT=%i
 ExecStart=/bin/bash -lc './alpha'
 Restart=always

--- a/spec/resources/export/systemd/app-bravo@.service
+++ b/spec/resources/export/systemd/app-bravo@.service
@@ -4,6 +4,7 @@ PartOf=app-bravo.target
 [Service]
 User=app
 WorkingDirectory=/tmp/app
+Environment=INSTANCE_NAME=%i
 Environment=PORT=%i
 ExecStart=/bin/bash -lc './bravo'
 Restart=always

--- a/spec/resources/export/upstart/app-alpha-1.conf
+++ b/spec/resources/export/upstart/app-alpha-1.conf
@@ -2,7 +2,9 @@ start on starting app-alpha
 stop on stopping app-alpha
 respawn
 
-env PORT=5000
+env INSTANCE_NAME='5000'
+env PS='alpha.1'
+env PORT='5000'
 
 setuid app
 

--- a/spec/resources/export/upstart/app-alpha-2.conf
+++ b/spec/resources/export/upstart/app-alpha-2.conf
@@ -2,7 +2,9 @@ start on starting app-alpha
 stop on stopping app-alpha
 respawn
 
-env PORT=5001
+env INSTANCE_NAME='5001'
+env PS='alpha.2'
+env PORT='5001'
 
 setuid app
 

--- a/spec/resources/export/upstart/app-bravo-1.conf
+++ b/spec/resources/export/upstart/app-bravo-1.conf
@@ -2,7 +2,9 @@ start on starting app-bravo
 stop on stopping app-bravo
 respawn
 
-env PORT=5100
+env INSTANCE_NAME='5100'
+env PS='bravo.1'
+env PORT='5100'
 
 setuid app
 


### PR DESCRIPTION
This PR replaces the instance identification from `PORT` to `INSTANCE_NAME` which can be populated with custom values. By default the old behaviour does not change, but is generated by `TCPUDPPortGenerator`. The `PORT` environment variable is still set when the instance name is a Fixnum.

This can be used for e.g. (in my case) serial ports or socket servers for e.g. nxing proxying.

Example (cwd = some projects root):

`lib/foreman_generators/socket_name_generator.rb`:
```ruby
module Foreman::InstanceNameGenerators
  class SocketNameGenerator
    attr_accessor :engine, :generator_idx

    def initialize(engine, generator_idx)
      @engine        = engine
      @generator_idx = generator_idx.to_int
    end

    def [](instance_idx)
      "socket-#{generator_idx +1}-#{instance_idx}"
    end
  end
end
```

`Procfile`:
```
app: bin/run-app
backup_app: bin/run-app
web: bin/rackup
```

`.foreman`:
```
load_path: lib/foreman_generators
require: socket_name_generator
formation: app=5,backup_app=2,web=1
instance_name_generators: app=SocketNameGenerator,backupapp=SocketNameGenerator
```

This will run one instance of rackup with `INSTANCE_NAME` (and `PORT`) set to 5000 and 5 app instances with `INSTANCE_NAME` set to `socket-1-1`, `socket-1-1`, ..., `socket-1-5` and 2 with `socket-2-1`, .., `socket-2-3`.