### PR TITLE
Support configuring the timestamp in Foreman::Engine::CLI output

### DIFF
--- a/lib/foreman/cli.rb
+++ b/lib/foreman/cli.rb
@@ -24,6 +24,7 @@ class Foreman::CLI < Thor
   method_option :formation, :type => :string,  :aliases => "-m", :banner => '"alpha=5,bar=3"', :desc => 'Specify what processes will run and how many. Default: "all=1"'
   method_option :port,      :type => :numeric, :aliases => "-p"
   method_option :timeout,   :type => :numeric, :aliases => "-t", :desc => "Specify the amount of time (in seconds) processes have to shutdown gracefully before receiving a SIGKILL, defaults to 5."
+  method_option :timestamp_format, :type => :string, :desc => "Specify the strftime format for output timestamps, defaults to %H:%M:%S."
 
   class << self
     # Hackery. Take the run method away from Thor so that we can redefine it.

--- a/lib/foreman/engine/cli.rb
+++ b/lib/foreman/engine/cli.rb
@@ -44,8 +44,14 @@ class Foreman::Engine::CLI < Foreman::Engine
 
   end
 
+  DEFAULT_TIMESTAMP_FORMAT = "%H:%M:%S".freeze
   FOREMAN_COLORS = %w( cyan yellow green magenta red blue bright_cyan bright_yellow
                        bright_green bright_magenta bright_red bright_blue )
+
+  def initialize(options={})
+    super
+    @options[:timestamp_format] ||= DEFAULT_TIMESTAMP_FORMAT
+  end
 
   def startup
     @colors = map_colors
@@ -57,7 +63,8 @@ class Foreman::Engine::CLI < Foreman::Engine
     data.to_s.lines.map(&:chomp).each do |message|
       output  = ""
       output += $stdout.color(@colors[name.split(".").first].to_sym)
-      output += "#{Time.now.strftime("%H:%M:%S")} #{pad_process_name(name)} | "
+      timestamp = Time.now.strftime(options[:timestamp_format])
+      output += "#{timestamp} #{pad_process_name(name)} | "
       output += $stdout.color(:reset)
       output += message
       $stdout.puts output

--- a/spec/foreman/cli_spec.rb
+++ b/spec/foreman/cli_spec.rb
@@ -56,6 +56,26 @@ describe "Foreman::CLI", :fakefs do
         output = `bundle exec foreman start -f #{resource_path "Procfile.bad"} && echo success`
         expect(output).not_to include 'success'
       end
+
+      it "logs with default timestamp format" do
+        Timecop.freeze do
+          without_fakefs do
+            output = foreman("start env -f #{resource_path("Procfile")}")
+            expected_timestamp = Time.now.strftime("%H:%M:%S")
+            expect(output).to include("#{expected_timestamp} env.1")
+          end
+        end
+      end
+
+      it "logs with specified timestamp format" do
+        Timecop.freeze do
+          without_fakefs do
+            output = foreman("start env -f #{resource_path("Procfile")} --timestamp_format %FT%T.%L%z")
+            expected_timestamp = Time.now.strftime("%FT%T.%L%z")
+            expect(output).to include("#{expected_timestamp} env.1")
+          end
+        end
+      end
     end
   end
 


### PR DESCRIPTION
I want the timestamp in `Foreman::Engine::CLI` output to be configurable.  The option `--timestamp_format` has been introduced for this purpose.