### PR TITLE
Foreman Export Upstart should not duplicate ports

### DIFF
--- a/data/export/upstart/process.conf.erb
+++ b/data/export/upstart/process.conf.erb
@@ -4,6 +4,7 @@ respawn
 
 env PORT=<%= port %>
 <% engine.env.each do |name,value| -%>
+<% next if name.upcase == "PORT" -%>
 env <%= name.upcase %>='<%= value.gsub(/'/, "'\"'\"'") %>'
 <% end -%>
 


### PR DESCRIPTION
Fixes #574. Better late than never.
