### PR TITLE
clean all upstart process files

### DIFF
--- a/lib/foreman/export/upstart.rb
+++ b/lib/foreman/export/upstart.rb
@@ -13,10 +13,11 @@ class Foreman::Export::Upstart < Foreman::Export::Base
 
     engine.each_process do |name, process|
       process_master_file = "#{app}-#{name}.conf"
-      
+      process_file = "#{app}-#{name}-%s.conf"
+
       Dir[
         File.join(location, process_master_file),
-        File.join(location, "#{app}-#{name}-*.conf")
+        File.join(location, process_file % "*")
       ].each { |f| clean(f) }
 
       next if engine.formation[name] < 1
@@ -24,8 +25,7 @@ class Foreman::Export::Upstart < Foreman::Export::Base
 
       1.upto(engine.formation[name]) do |num|
         port = engine.port_for(process, num)
-        process_file = "#{app}-#{name}-#{num}.conf"
-        write_template process_template, process_file, binding
+        write_template process_template, process_file % num, binding
       end
     end
   end

--- a/lib/foreman/export/upstart.rb
+++ b/lib/foreman/export/upstart.rb
@@ -13,7 +13,11 @@ class Foreman::Export::Upstart < Foreman::Export::Base
 
     engine.each_process do |name, process|
       process_master_file = "#{app}-#{name}.conf"
-      clean File.join(location, process_master_file)
+      
+      Dir[
+        File.join(location, process_master_file),
+        File.join(location, "#{app}-#{name}-*.conf")
+      ].each { |f| clean(f) }
 
       next if engine.formation[name] < 1
       write_template process_master_template, process_master_file, binding
@@ -21,7 +25,6 @@ class Foreman::Export::Upstart < Foreman::Export::Base
       1.upto(engine.formation[name]) do |num|
         port = engine.port_for(process, num)
         process_file = "#{app}-#{name}-#{num}.conf"
-        clean File.join(location, process_file)
         write_template process_template, process_file, binding
       end
     end


### PR DESCRIPTION
instead of cleaning only for the number of processes defined in the
formation, we now remove all files using a glob.

intentionally not moving the glob higher up, because that has a higher
risk of matching files that do not belong to the application.

fixes #646
