### PR TITLE
Port to rspec 3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,8 +5,7 @@ gemspec
 group :test do
   gem 'rake'
   gem 'fakefs', '~> 0.4.0'
-  gem 'rr',     '~> 1.0.2'
-  gem 'rspec',  '~> 2.99.0'
+  gem 'rspec',  '~> 3.5'
   gem "simplecov", :require => false
   gem 'timecop'
   gem "codeclimate-test-reporter", :require => false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,15 +31,19 @@ GEM
       hpricot (>= 0.8.2)
       mustache (>= 0.7.0)
       rdiscount (>= 1.5.8)
-    rr (1.0.5)
-    rspec (2.99.0)
-      rspec-core (~> 2.99.0)
-      rspec-expectations (~> 2.99.0)
-      rspec-mocks (~> 2.99.0)
-    rspec-core (2.99.2)
-    rspec-expectations (2.99.2)
-      diff-lcs (>= 1.1.3, < 2.0)
-    rspec-mocks (2.99.4)
+    rspec (3.5.0)
+      rspec-core (~> 3.5.0)
+      rspec-expectations (~> 3.5.0)
+      rspec-mocks (~> 3.5.0)
+    rspec-core (3.5.4)
+      rspec-support (~> 3.5.0)
+    rspec-expectations (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-mocks (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-support (3.5.0)
     simplecov (0.11.2)
       docile (~> 1.1.0)
       json (~> 1.8)
@@ -62,8 +66,7 @@ DEPENDENCIES
   foreman!
   rake
   ronn
-  rr (~> 1.0.2)
-  rspec (~> 2.99.0)
+  rspec (~> 3.5)
   simplecov
   timecop
   yard

--- a/spec/foreman/cli_spec.rb
+++ b/spec/foreman/cli_spec.rb
@@ -21,7 +21,7 @@ describe "Foreman::CLI", :fakefs do
     describe "when a Procfile doesnt exist", :fakefs do
       it "displays an error" do
         mock_error(subject, "Procfile does not exist.") do
-          dont_allow.instance_of(Foreman::Engine).start
+          expect_any_instance_of(Foreman::Engine).to_not receive(:start)
           subject.start
         end
       end

--- a/spec/foreman/engine_spec.rb
+++ b/spec/foreman/engine_spec.rb
@@ -35,19 +35,19 @@ describe "Foreman::Engine", :fakefs do
 
   describe "start" do
     it "forks the processes" do
-      mock(subject.process("alpha")).run(anything)
-      mock(subject.process("bravo")).run(anything)
-      mock(subject).watch_for_output
-      mock(subject).wait_for_shutdown_or_child_termination
+      expect(subject.process("alpha")).to receive(:run)
+      expect(subject.process("bravo")).to receive(:run)
+      expect(subject).to receive(:watch_for_output)
+      expect(subject).to receive(:wait_for_shutdown_or_child_termination)
       subject.start
     end
 
     it "handles concurrency" do
       subject.options[:formation] = "alpha=2"
-      mock(subject.process("alpha")).run(anything).twice
-      mock(subject.process("bravo")).run(anything).never
-      mock(subject).watch_for_output
-      mock(subject).wait_for_shutdown_or_child_termination
+      expect(subject.process("alpha")).to receive(:run).twice
+      expect(subject.process("bravo")).to_not receive(:run)
+      expect(subject).to receive(:watch_for_output)
+      expect(subject).to receive(:wait_for_shutdown_or_child_termination)
       subject.start
     end
   end

--- a/spec/foreman/export/base_spec.rb
+++ b/spec/foreman/export/base_spec.rb
@@ -9,7 +9,7 @@ describe "Foreman::Export::Base", :fakefs do
   let(:subject)  { Foreman::Export::Base.new(location, engine) }
 
   it "has a say method for displaying info" do
-    mock(subject).puts("[foreman export] foo")
+    expect(subject).to receive(:puts).with("[foreman export] foo")
     subject.send(:say, "foo")
   end
 

--- a/spec/foreman/export/bluepill_spec.rb
+++ b/spec/foreman/export/bluepill_spec.rb
@@ -11,7 +11,7 @@ describe Foreman::Export::Bluepill, :fakefs do
   let(:bluepill)  { Foreman::Export::Bluepill.new("/tmp/init", engine, options) }
 
   before(:each) { load_export_templates_into_fakefs("bluepill") }
-  before(:each) { stub(bluepill).say }
+  before(:each) { allow(bluepill).to receive(:say) }
 
   it "exports to the filesystem" do
     bluepill.export
@@ -19,7 +19,7 @@ describe Foreman::Export::Bluepill, :fakefs do
   end
 
   it "cleans up if exporting into an existing dir" do
-    mock(FileUtils).rm("/tmp/init/app.pill")
+    expect(FileUtils).to receive(:rm).with("/tmp/init/app.pill")
 
     bluepill.export
     bluepill.export

--- a/spec/foreman/export/daemon_spec.rb
+++ b/spec/foreman/export/daemon_spec.rb
@@ -11,7 +11,7 @@ describe Foreman::Export::Daemon, :fakefs do
   let(:daemon)   { Foreman::Export::Daemon.new("/tmp/init", engine, options) }
 
   before(:each) { load_export_templates_into_fakefs("daemon") }
-  before(:each) { stub(daemon).say }
+  before(:each) { allow(daemon).to receive(:say) }
 
   it "exports to the filesystem" do
     daemon.export
@@ -24,15 +24,15 @@ describe Foreman::Export::Daemon, :fakefs do
   end
 
   it "cleans up if exporting into an existing dir" do
-    mock(FileUtils).rm("/tmp/init/app.conf")
-    mock(FileUtils).rm("/tmp/init/app-alpha.conf")
-    mock(FileUtils).rm("/tmp/init/app-alpha-1.conf")
-    mock(FileUtils).rm("/tmp/init/app-bravo.conf")
-    mock(FileUtils).rm("/tmp/init/app-bravo-1.conf")
-    mock(FileUtils).rm("/tmp/init/app-foo-bar.conf")
-    mock(FileUtils).rm("/tmp/init/app-foo-bar-1.conf")
-    mock(FileUtils).rm("/tmp/init/app-foo_bar.conf")
-    mock(FileUtils).rm("/tmp/init/app-foo_bar-1.conf")
+    expect(FileUtils).to receive(:rm).with("/tmp/init/app.conf")
+    expect(FileUtils).to receive(:rm).with("/tmp/init/app-alpha.conf")
+    expect(FileUtils).to receive(:rm).with("/tmp/init/app-alpha-1.conf")
+    expect(FileUtils).to receive(:rm).with("/tmp/init/app-bravo.conf")
+    expect(FileUtils).to receive(:rm).with("/tmp/init/app-bravo-1.conf")
+    expect(FileUtils).to receive(:rm).with("/tmp/init/app-foo-bar.conf")
+    expect(FileUtils).to receive(:rm).with("/tmp/init/app-foo-bar-1.conf")
+    expect(FileUtils).to receive(:rm).with("/tmp/init/app-foo_bar.conf")
+    expect(FileUtils).to receive(:rm).with("/tmp/init/app-foo_bar-1.conf")
 
     daemon.export
     daemon.export
@@ -44,7 +44,7 @@ describe Foreman::Export::Daemon, :fakefs do
     ["app2", "app2-alpha", "app2-alpha-1"].each do |name|
       path = "/tmp/init/#{name}.conf"
       FileUtils.touch(path)
-      dont_allow(FileUtils).rm(path)
+      expect(FileUtils).to_not receive(:rm).with(path)
     end
 
     daemon.export

--- a/spec/foreman/export/inittab_spec.rb
+++ b/spec/foreman/export/inittab_spec.rb
@@ -12,7 +12,7 @@ describe Foreman::Export::Inittab, :fakefs do
   let(:inittab)   { Foreman::Export::Inittab.new(location, engine, options) }
 
   before(:each) { load_export_templates_into_fakefs("inittab") }
-  before(:each) { stub(inittab).say }
+  before(:each) { allow(inittab).to receive(:say) }
 
   it "exports to the filesystem" do
     inittab.export
@@ -23,7 +23,7 @@ describe Foreman::Export::Inittab, :fakefs do
     let(:location) { "-" }
 
     it "exports to stdout" do
-      mock(inittab).puts example_export_file("inittab/inittab.default")
+      expect(inittab).to receive(:puts).with(example_export_file("inittab/inittab.default"))
       inittab.export
     end
   end

--- a/spec/foreman/export/launchd_spec.rb
+++ b/spec/foreman/export/launchd_spec.rb
@@ -10,7 +10,7 @@ describe Foreman::Export::Launchd, :fakefs do
   let(:launchd)  { Foreman::Export::Launchd.new("/tmp/init", engine, options) }
 
   before(:each) { load_export_templates_into_fakefs("launchd") }
-  before(:each) { stub(launchd).say }
+  before(:each) { allow(launchd).to receive(:say) }
 
   it "exports to the filesystem" do
     launchd.export

--- a/spec/foreman/export/runit_spec.rb
+++ b/spec/foreman/export/runit_spec.rb
@@ -10,8 +10,8 @@ describe Foreman::Export::Runit, :fakefs do
   let(:runit)    { Foreman::Export::Runit.new('/tmp/init', engine, options) }
 
   before(:each) { load_export_templates_into_fakefs("runit") }
-  before(:each) { stub(runit).say }
-  before(:each) { stub(FakeFS::FileUtils).chmod }
+  before(:each) { allow(runit).to receive(:say) }
+  before(:each) { allow(FakeFS::FileUtils).to receive(:chmod) }
 
   it "exports to the filesystem" do
     engine.env["BAR"] = "baz"

--- a/spec/foreman/export/supervisord_spec.rb
+++ b/spec/foreman/export/supervisord_spec.rb
@@ -11,7 +11,7 @@ describe Foreman::Export::Supervisord, :fakefs do
   let(:supervisord) { Foreman::Export::Supervisord.new("/tmp/init", engine, options) }
 
   before(:each) { load_export_templates_into_fakefs("supervisord") }
-  before(:each) { stub(supervisord).say }
+  before(:each) { allow(supervisord).to receive(:say) }
 
   it "exports to the filesystem" do
     write_env(".env", "FOO"=>"bar", "URL"=>"http://example.com/api?foo=bar&baz=1")
@@ -21,7 +21,7 @@ describe Foreman::Export::Supervisord, :fakefs do
   end
 
   it "cleans up if exporting into an existing dir" do
-    mock(FileUtils).rm("/tmp/init/app.conf")
+    expect(FileUtils).to receive(:rm).with("/tmp/init/app.conf")
     supervisord.export
     supervisord.export
   end

--- a/spec/foreman/export/systemd_spec.rb
+++ b/spec/foreman/export/systemd_spec.rb
@@ -11,7 +11,7 @@ describe Foreman::Export::Systemd, :fakefs do
   let(:systemd)   { Foreman::Export::Systemd.new("/tmp/init", engine, options) }
 
   before(:each) { load_export_templates_into_fakefs("systemd") }
-  before(:each) { stub(systemd).say }
+  before(:each) { allow(systemd).to receive(:say) }
 
   it "exports to the filesystem" do
     systemd.export
@@ -27,27 +27,27 @@ describe Foreman::Export::Systemd, :fakefs do
   end
 
   it "cleans up if exporting into an existing dir" do
-    mock(FileUtils).rm("/tmp/init/app.target")
+    expect(FileUtils).to receive(:rm).with("/tmp/init/app.target")
 
-    mock(FileUtils).rm("/tmp/init/app-alpha@.service")
-    mock(FileUtils).rm("/tmp/init/app-alpha.target")
-    mock(FileUtils).rm("/tmp/init/app-alpha.target.wants/app-alpha@5000.service")
-    mock(FileUtils).rm_r("/tmp/init/app-alpha.target.wants")
+    expect(FileUtils).to receive(:rm).with("/tmp/init/app-alpha@.service")
+    expect(FileUtils).to receive(:rm).with("/tmp/init/app-alpha.target")
+    expect(FileUtils).to receive(:rm).with("/tmp/init/app-alpha.target.wants/app-alpha@5000.service")
+    expect(FileUtils).to receive(:rm_r).with("/tmp/init/app-alpha.target.wants")
 
-    mock(FileUtils).rm("/tmp/init/app-bravo.target")
-    mock(FileUtils).rm("/tmp/init/app-bravo@.service")
-    mock(FileUtils).rm("/tmp/init/app-bravo.target.wants/app-bravo@5100.service")
-    mock(FileUtils).rm_r("/tmp/init/app-bravo.target.wants")
+    expect(FileUtils).to receive(:rm).with("/tmp/init/app-bravo.target")
+    expect(FileUtils).to receive(:rm).with("/tmp/init/app-bravo@.service")
+    expect(FileUtils).to receive(:rm).with("/tmp/init/app-bravo.target.wants/app-bravo@5100.service")
+    expect(FileUtils).to receive(:rm_r).with("/tmp/init/app-bravo.target.wants")
 
-    mock(FileUtils).rm("/tmp/init/app-foo_bar.target")
-    mock(FileUtils).rm("/tmp/init/app-foo_bar@.service")
-    mock(FileUtils).rm("/tmp/init/app-foo_bar.target.wants/app-foo_bar@5200.service")
-    mock(FileUtils).rm_r("/tmp/init/app-foo_bar.target.wants")
+    expect(FileUtils).to receive(:rm).with("/tmp/init/app-foo_bar.target")
+    expect(FileUtils).to receive(:rm).with("/tmp/init/app-foo_bar@.service")
+    expect(FileUtils).to receive(:rm).with("/tmp/init/app-foo_bar.target.wants/app-foo_bar@5200.service")
+    expect(FileUtils).to receive(:rm_r).with("/tmp/init/app-foo_bar.target.wants")
 
-    mock(FileUtils).rm("/tmp/init/app-foo-bar.target")
-    mock(FileUtils).rm("/tmp/init/app-foo-bar@.service")
-    mock(FileUtils).rm("/tmp/init/app-foo-bar.target.wants/app-foo-bar@5300.service")
-    mock(FileUtils).rm_r("/tmp/init/app-foo-bar.target.wants")
+    expect(FileUtils).to receive(:rm).with("/tmp/init/app-foo-bar.target")
+    expect(FileUtils).to receive(:rm).with("/tmp/init/app-foo-bar@.service")
+    expect(FileUtils).to receive(:rm).with("/tmp/init/app-foo-bar.target.wants/app-foo-bar@5300.service")
+    expect(FileUtils).to receive(:rm_r).with("/tmp/init/app-foo-bar.target.wants")
 
 
     systemd.export

--- a/spec/foreman/export/upstart_spec.rb
+++ b/spec/foreman/export/upstart_spec.rb
@@ -11,7 +11,7 @@ describe Foreman::Export::Upstart, :fakefs do
   let(:upstart)   { Foreman::Export::Upstart.new("/tmp/init", engine, options) }
 
   before(:each) { load_export_templates_into_fakefs("upstart") }
-  before(:each) { stub(upstart).say }
+  before(:each) { allow(upstart).to receive(:say) }
 
   it "exports to the filesystem" do
     upstart.export
@@ -24,15 +24,15 @@ describe Foreman::Export::Upstart, :fakefs do
   end
 
   it "cleans up if exporting into an existing dir" do
-    mock(FileUtils).rm("/tmp/init/app.conf")
-    mock(FileUtils).rm("/tmp/init/app-alpha.conf")
-    mock(FileUtils).rm("/tmp/init/app-alpha-1.conf")
-    mock(FileUtils).rm("/tmp/init/app-bravo.conf")
-    mock(FileUtils).rm("/tmp/init/app-bravo-1.conf")
-    mock(FileUtils).rm("/tmp/init/app-foo-bar.conf")
-    mock(FileUtils).rm("/tmp/init/app-foo-bar-1.conf")
-    mock(FileUtils).rm("/tmp/init/app-foo_bar.conf")
-    mock(FileUtils).rm("/tmp/init/app-foo_bar-1.conf")
+    expect(FileUtils).to receive(:rm).with("/tmp/init/app.conf")
+    expect(FileUtils).to receive(:rm).with("/tmp/init/app-alpha.conf")
+    expect(FileUtils).to receive(:rm).with("/tmp/init/app-alpha-1.conf")
+    expect(FileUtils).to receive(:rm).with("/tmp/init/app-bravo.conf")
+    expect(FileUtils).to receive(:rm).with("/tmp/init/app-bravo-1.conf")
+    expect(FileUtils).to receive(:rm).with("/tmp/init/app-foo-bar.conf")
+    expect(FileUtils).to receive(:rm).with("/tmp/init/app-foo-bar-1.conf")
+    expect(FileUtils).to receive(:rm).with("/tmp/init/app-foo_bar.conf")
+    expect(FileUtils).to receive(:rm).with("/tmp/init/app-foo_bar-1.conf")
 
     upstart.export
     upstart.export
@@ -44,7 +44,7 @@ describe Foreman::Export::Upstart, :fakefs do
     ["app2", "app2-alpha", "app2-alpha-1"].each do |name|
       path = "/tmp/init/#{name}.conf"
       FileUtils.touch(path)
-      dont_allow(FileUtils).rm(path)
+      expect(FileUtils).to_not receive(:rm).with(path)
     end
 
     upstart.export
@@ -56,7 +56,7 @@ describe Foreman::Export::Upstart, :fakefs do
     ["app-worker", "app-worker-worker", "app-worker-worker-1"].each do |name|
       path = "/tmp/init/#{name}.conf"
       FileUtils.touch(path)
-      dont_allow(FileUtils).rm(path)
+      expect(FileUtils).to_not receive(:rm).with(path)
     end
 
     upstart.export

--- a/spec/foreman/export_spec.rb
+++ b/spec/foreman/export_spec.rb
@@ -6,7 +6,7 @@ describe "Foreman::Export" do
 
   describe "with a formatter that doesn't declare the appropriate class" do
     it "prints an error" do
-      mock(subject).require("foreman/export/invalidformatter")
+      expect(subject).to receive(:require).with("foreman/export/invalidformatter")
       mock_export_error("Unknown export format: invalidformatter (no class Foreman::Export::Invalidformatter).") do
         subject.formatter("invalidformatter") 
       end

--- a/spec/foreman/process_spec.rb
+++ b/spec/foreman/process_spec.rb
@@ -55,13 +55,13 @@ describe Foreman::Process do
     end
 
     it "can execute" do
-      mock(Kernel).exec "bin/command"
+      expect(Kernel).to receive(:exec).with("bin/command")
       process = Foreman::Process.new("bin/command")
       process.exec
     end
 
     it "can execute with env" do
-      mock(Kernel).exec "bin/command bar"
+      expect(Kernel).to receive(:exec).with("bin/command bar")
       process = Foreman::Process.new("bin/command $FOO")
       process.exec(:env => { "FOO" => "bar" })
     end

--- a/spec/foreman_spec.rb
+++ b/spec/foreman_spec.rb
@@ -5,7 +5,7 @@ describe Foreman do
 
   describe "VERSION" do
     subject { Foreman::VERSION }
-    it { should be_a String }
+    it { is_expected.to be_a String }
   end
 
   describe "runner" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,7 +19,7 @@ end
 
 def mock_error(subject, message)
   mock_exit do
-    mock(subject).puts("ERROR: #{message}")
+    expect(subject).to receive(:puts).with("ERROR: #{message}")
     yield
   end
 end
@@ -166,11 +166,9 @@ ensure
 end
 
 RSpec.configure do |config|
-  config.treat_symbols_as_metadata_keys_with_true_values = true
   config.color = true
   config.order = 'rand'
   config.include FakeFS::SpecHelpers, :fakefs
-  config.mock_with :rr
   config.before(:each) do
     FileUtils.mkdir_p('/tmp')
   end


### PR DESCRIPTION
Also migrate all usage of `rr` to rspec mocks, so `rr` is not needed to
run tests anymore.