### PR TITLE
JSON Output Formatter

### DIFF
--- a/lib/foreman/cli.rb
+++ b/lib/foreman/cli.rb
@@ -53,7 +53,7 @@ class Foreman::CLI < Thor
   method_option :port,        :type => :numeric, :aliases => "-p"
   method_option :user,        :type => :string,  :aliases => "-u"
   method_option :template,    :type => :string,  :aliases => "-t"
-  method_option :formation,   :type => :string,  :aliases => "-m", :banner => '"alpha=5,bar=3"', :desc => 'Specify what processes will run and how many. Default: "all=1"'
+  method_option :formation, :type => :string,  :aliases => "-m", :banner => '"alpha=5,bar=3"', :desc => 'Specify what processes will run and how many. Default: "all=1"'
   method_option :timeout,     :type => :numeric, :aliases => "-t", :desc => "Specify the amount of time (in seconds) processes have to shutdown gracefully before receiving a SIGKILL, defaults to 5."
 
   def export(format, location=nil)

--- a/lib/foreman/engine/json_cli.rb
+++ b/lib/foreman/engine/json_cli.rb
@@ -11,7 +11,7 @@ class Foreman::Engine::JsonCLI < Foreman::Engine
       begin
         json_data = JSON.parse(message).to_json
       rescue JSON::ParserError
-        json_data = { line: message }.to_json
+        json_data = { logline: message }.to_json
       end
       json_data.insert(1, "\"process_name\":\"#{name}\", ")
       json_data.insert(1, "\"application_server_timestamp\":\"#{Time.now.strftime("%Y-%m-%d %H:%M:%S.%6N %z")}\", ")

--- a/lib/foreman/engine/json_cli.rb
+++ b/lib/foreman/engine/json_cli.rb
@@ -9,12 +9,12 @@ class Foreman::Engine::JsonCLI < Foreman::Engine
   def output(name, data)
     data.to_s.lines.map(&:chomp).each do |message|
       begin
-        json_data = JSON.parse(message).to_s
+        json_data = JSON.parse(message).to_json
       rescue JSON::ParserError
         json_data = { line: message }.to_json
       end
       json_data.insert(1, "\"process_name\":\"#{name}\", ")
-      json_data.insert(1, "\"application_server_timestamp\":\"#{Time.now.utc.to_s}\", ")
+      json_data.insert(1, "\"application_server_timestamp\":\"#{Time.now.strftime("%Y-%m-%d %H:%M:%S.%6N %z")}\", ")
       output = json_data
       $stdout.puts output
     end

--- a/lib/foreman/engine/json_cli.rb
+++ b/lib/foreman/engine/json_cli.rb
@@ -1,0 +1,29 @@
+require "json"
+require "foreman/engine"
+
+class Foreman::Engine::JsonCLI < Foreman::Engine
+
+  def startup
+  end
+
+  def output(name, data)
+    data.to_s.lines.map(&:chomp).each do |message|
+      begin
+        json_data = JSON.parse(message).to_s
+      rescue JSON::ParserError
+        json_data = { line: message }.to_json
+      end
+      json_data.insert(1, "\"process_name\":\"#{name}\", ")
+      json_data.insert(1, "\"application_server_timestamp\":\"#{Time.now.utc.to_s}\", ")
+      output = json_data
+      $stdout.puts output
+    end
+    $stdout.flush
+  rescue Errno::EPIPE
+    terminate_gracefully
+  end
+
+  def shutdown
+  end
+
+end

--- a/spec/foreman/cli_spec.rb
+++ b/spec/foreman/cli_spec.rb
@@ -52,6 +52,15 @@ describe "Foreman::CLI", :fakefs do
         end
       end
 
+      it "selects the JSON CLI engine Class if requested" do
+        without_fakefs do
+          output = foreman("start -j -f #{resource_path("Procfile")}")
+          expect(output).to match(/{"application_server_timestamp":/)
+          expect(output).to match(/"process_name":"echo.1"/)
+          expect(JSON.parse(output.lines[0])).not_to be_empty
+        end
+      end
+
       it "fails if process fails" do
         output = `bundle exec foreman start -f #{resource_path "Procfile.bad"} && echo success`
         expect(output).not_to include 'success'


### PR DESCRIPTION
I'm working on a project and needed JSON for all output for log parsing.
I built a simple JSON CLI Engine that formats as follows ( using sample Procfile )

`foreman start -j -f spec/resources/Procfile`

Let me know any comments anyone has and I'm happy to adjust.

Thanks.

```
{"application_server_timestamp":"2016-11-28 22:56:45 UTC", "process_name":"echo.1", "line":"started with pid 52092"}
{"application_server_timestamp":"2016-11-28 22:56:45 UTC", "process_name":"env.1", "line":"started with pid 52093"}
{"application_server_timestamp":"2016-11-28 22:56:45 UTC", "process_name":"test.1", "line":"started with pid 52094"}
{"application_server_timestamp":"2016-11-28 22:56:45 UTC", "process_name":"utf8.1", "line":"started with pid 52095"}
{"application_server_timestamp":"2016-11-28 22:56:45 UTC", "process_name":"ps.1", "line":"started with pid 52096"}
{"application_server_timestamp":"2016-11-28 22:56:45 UTC", "process_name":"echo.1", "line":"echoing"}
{"application_server_timestamp":"2016-11-28 22:56:45 UTC", "process_name":"env.1", "line":""}
{"application_server_timestamp":"2016-11-28 22:56:45 UTC", "process_name":"test.1", "line":"testing"}
{"application_server_timestamp":"2016-11-28 22:56:45 UTC", "process_name":"ps.1", "line":"PS env var is ps.1"}
{"application_server_timestamp":"2016-11-28 22:56:45 UTC", "process_name":"ps.1", "line":"exited with code 0"}
{"application_server_timestamp":"2016-11-28 22:56:45 UTC", "process_name":"system", "line":"sending SIGTERM to all processes"}
{"application_server_timestamp":"2016-11-28 22:56:45 UTC", "process_name":"test.1", "line":"exited with code 0"}
{"application_server_timestamp":"2016-11-28 22:56:45 UTC", "process_name":"utf8.1", "line":"terminated by SIGTERM"}
{"application_server_timestamp":"2016-11-28 22:56:46 UTC", "process_name":"env.1", "line":"exited with code 0"}
{"application_server_timestamp":"2016-11-28 22:56:46 UTC", "process_name":"echo.1", "line":"exited with code 0"}
{"application_server_timestamp":"2016-11-28 22:56:45 UTC", "process_name":"echo.1", "line":"started with pid 52092"}
```
