### PR TITLE
Change systemd KillMode to "mixed"

### DIFF
--- a/data/export/systemd/process.service.erb
+++ b/data/export/systemd/process.service.erb
@@ -5,7 +5,7 @@ PartOf=<%= app %>-<%= name %>.target
 User=<%= user %>
 WorkingDirectory=<%= engine.root %>
 Environment=PORT=%i
-<% if !engine.env.empty? %>Environment=<% engine.env.each_pair do |var,env| %>"<%= var.upcase %>=<%= env %>" <% end %><% end %>
+<% if !engine.env.empty? -%>Environment=<% engine.env.each_pair do |var,env| %>"<%= var.upcase %>=<%= env %>" <% end %><% end -%>
 ExecStart=/bin/bash -lc '<%= process.command %>'
 Restart=always
 StandardInput=null

--- a/data/export/systemd/process.service.erb
+++ b/data/export/systemd/process.service.erb
@@ -12,5 +12,5 @@ StandardInput=null
 StandardOutput=syslog
 StandardError=syslog
 SyslogIdentifier=%n
-KillMode=process
+KillMode=mixed
 TimeoutStopSec=<%= engine.options[:timeout] %>

--- a/spec/foreman/export/systemd_spec.rb
+++ b/spec/foreman/export/systemd_spec.rb
@@ -57,7 +57,7 @@ describe Foreman::Export::Systemd, :fakefs do
   it "includes environment variables" do
     engine.env['KEY'] = 'some "value"'
     systemd.export
-    expect(File.read("/tmp/init/app-alpha@.service")).to match(/KEY=some "value"$/)
+    expect(File.read("/tmp/init/app-alpha@.service")).to match(/KEY=some "value"/)
   end
 
   context "with a formation" do

--- a/spec/resources/export/systemd/app-alpha@.service
+++ b/spec/resources/export/systemd/app-alpha@.service
@@ -11,5 +11,5 @@ StandardInput=null
 StandardOutput=syslog
 StandardError=syslog
 SyslogIdentifier=%n
-KillMode=process
+KillMode=mixed
 TimeoutStopSec=5

--- a/spec/resources/export/systemd/app-bravo@.service
+++ b/spec/resources/export/systemd/app-bravo@.service
@@ -11,5 +11,5 @@ StandardInput=null
 StandardOutput=syslog
 StandardError=syslog
 SyslogIdentifier=%n
-KillMode=process
+KillMode=mixed
 TimeoutStopSec=5

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,7 @@ end
 
 require "rspec"
 require "timecop"
+require "pp"
 require "fakefs/safe"
 require "fakefs/spec_helpers"
 


### PR DESCRIPTION
Based on #657
Paired with @alexispeter

Possible values are:
- control-group: all remaining processes in the control group of this unit will be killed on unit stop
- process: only the main process itself is killed
- mixed: the SIGTERM signal is sent to the main process while the subsequent SIGKILL signal is sent to all remaining processes of the unit's control group

See https://www.freedesktop.org/software/systemd/man/systemd.kill.html#KillMode=

The current value of "process" will overlook any remaining forked/daemonized processes. When stopping or restarting such a process, child processes can become zombies.
When instead using "mixed" systemd will send a SIGKILL signal to all remaining processes of the same control group, and thus prevent zombies.
We should always try to prevent zombies.