### PR TITLE
Add option to suppress timestamps

### DIFF
--- a/lib/foreman/cli.rb
+++ b/lib/foreman/cli.rb
@@ -24,6 +24,7 @@ class Foreman::CLI < Thor
   method_option :formation, :type => :string,  :aliases => "-m", :banner => '"alpha=5,bar=3"', :desc => 'Specify what processes will run and how many. Default: "all=1"'
   method_option :port,      :type => :numeric, :aliases => "-p"
   method_option :timeout,   :type => :numeric, :aliases => "-t", :desc => "Specify the amount of time (in seconds) processes have to shutdown gracefully before receiving a SIGKILL, defaults to 5."
+  method_option :timestamp, :type => :boolean, :default => true, :desc => "Include timestamp in output"
 
   class << self
     # Hackery. Take the run method away from Thor so that we can redefine it.

--- a/lib/foreman/engine/cli.rb
+++ b/lib/foreman/engine/cli.rb
@@ -57,7 +57,8 @@ class Foreman::Engine::CLI < Foreman::Engine
     data.to_s.lines.map(&:chomp).each do |message|
       output  = ""
       output += $stdout.color(@colors[name.split(".").first].to_sym)
-      output += "#{Time.now.strftime("%H:%M:%S")} #{pad_process_name(name)} | "
+      output += "#{Time.now.strftime("%H:%M:%S")} " if options[:timestamp]
+      output += "#{pad_process_name(name)} | "
       output += $stdout.color(:reset)
       output += message
       $stdout.puts output


### PR DESCRIPTION
Hello and thank you for foreman! We use to start multiple processes in a container-based PaaS. The PaaS logging system prepends timestamps to all log lines, so we end up getting duplicate timestamps in log output: the first comes from foreman and the second comes from the PaaS.

This PR adds an option, `--no-timestamp`, to suppress timestamps from foreman log lines.