### PR TITLE
Supervisor Defaults

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gemspec
 
 group :test do
   gem 'rake'
-  gem 'fakefs', '~> 0.4.0'
+  gem 'fakefs', '~> 0.10.0'
   gem 'rspec',  '~> 3.5'
   gem "simplecov", :require => false
   gem 'timecop'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,7 +16,7 @@ GEM
       simplecov (>= 0.7.1, < 1.0.0)
     diff-lcs (1.2.5)
     docile (1.1.5)
-    fakefs (0.4.3)
+    fakefs (0.10.1)
     hpricot (0.8.6)
     hpricot (0.8.6-java)
     json (1.8.3)
@@ -62,7 +62,7 @@ PLATFORMS
 DEPENDENCIES
   aws-s3
   codeclimate-test-reporter
-  fakefs (~> 0.4.0)
+  fakefs (~> 0.10.0)
   foreman!
   rake
   ronn
@@ -72,4 +72,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   1.11.2
+   1.13.7

--- a/data/export/supervisord/app.conf.erb
+++ b/data/export/supervisord/app.conf.erb
@@ -17,7 +17,6 @@ engine.each_process do |name, process|
 command=<%= process.command %>
 autostart=true
 autorestart=true
-stopsignal=QUIT
 stdout_logfile=<%= log %>/<%= name %>-<%= num %>.log
 stderr_logfile=<%= log %>/<%= name %>-<%= num %>.error.log
 user=<%= user %>

--- a/spec/resources/export/supervisord/app-alpha-1.conf
+++ b/spec/resources/export/supervisord/app-alpha-1.conf
@@ -2,7 +2,6 @@
 command=./alpha
 autostart=true
 autorestart=true
-stopsignal=QUIT
 stdout_logfile=/var/log/app/alpha-1.log
 stderr_logfile=/var/log/app/alpha-1.error.log
 user=app
@@ -13,7 +12,6 @@ environment=FOO="bar",URL="http://example.com/api?foo=bar&baz=1",PORT="5000"
 command=./bravo
 autostart=true
 autorestart=true
-stopsignal=QUIT
 stdout_logfile=/var/log/app/bravo-1.log
 stderr_logfile=/var/log/app/bravo-1.error.log
 user=app
@@ -24,7 +22,6 @@ environment=FOO="bar",URL="http://example.com/api?foo=bar&baz=1",PORT="5100"
 command=./foo_bar
 autostart=true
 autorestart=true
-stopsignal=QUIT
 stdout_logfile=/var/log/app/foo_bar-1.log
 stderr_logfile=/var/log/app/foo_bar-1.error.log
 user=app
@@ -35,7 +32,6 @@ environment=FOO="bar",URL="http://example.com/api?foo=bar&baz=1",PORT="5200"
 command=./foo-bar
 autostart=true
 autorestart=true
-stopsignal=QUIT
 stdout_logfile=/var/log/app/foo-bar-1.log
 stderr_logfile=/var/log/app/foo-bar-1.error.log
 user=app

--- a/spec/resources/export/supervisord/app-alpha-2.conf
+++ b/spec/resources/export/supervisord/app-alpha-2.conf
@@ -2,7 +2,6 @@
 command=./alpha
 autostart=true
 autorestart=true
-stopsignal=QUIT
 stdout_logfile=/var/log/app/alpha-1.log
 stderr_logfile=/var/log/app/alpha-1.error.log
 user=app
@@ -13,7 +12,6 @@ environment=PORT="5000"
 command=./alpha
 autostart=true
 autorestart=true
-stopsignal=QUIT
 stdout_logfile=/var/log/app/alpha-2.log
 stderr_logfile=/var/log/app/alpha-2.error.log
 user=app


### PR DESCRIPTION
Hi @ddollar!

First of all thank you for this cool gem!

I would like to propose that foreman follows the defaults from Supervisor. I learned that some processes do not respond well to `SIGQUIT` but prefer `SIGTERM`. And while `SIGTERM` is actually the Supervisor's default stop signal, I thought it's a good idea to use it. What do you think?

PS: I also upgraded the fakefs gem because it spit out some warnings during testing.