### PR TITLE
Add error for missing .env file

### DIFF
--- a/lib/foreman/cli.rb
+++ b/lib/foreman/cli.rb
@@ -141,6 +141,7 @@ private ######################################################################
       end
     else
       default_env = File.join(engine.root, ".env")
+      error(".env file does not exist.") unless File.file?(default_env)
       engine.load_env default_env if File.file?(default_env)
     end
   end


### PR DESCRIPTION
- Currently, if the .env file is missing, none of the variables get set, and everything fails. The error messages are similar to error messages you might get for a .env file with the wrong content.
- Would be great to throw an error indicating that the .env file is completely missing.