### PR TITLE
make systemctl stop/restart/reload work

### DIFF
--- a/data/export/systemd/process.service.erb
+++ b/data/export/systemd/process.service.erb
@@ -6,7 +6,7 @@ User=<%= user %>
 WorkingDirectory=<%= engine.root %>
 Environment=PORT=%i
 <% if !engine.env.empty? -%>Environment=<% engine.env.each_pair do |var,env| %>"<%= var.upcase %>=<%= env %>" <% end %><% end -%>
-ExecStart=/bin/bash -lc '<%= process.command %>'
+ExecStart=/bin/bash -lc 'exec <%= process.command %>'
 Restart=always
 StandardInput=null
 StandardOutput=syslog

--- a/spec/resources/export/systemd/app-alpha@.service
+++ b/spec/resources/export/systemd/app-alpha@.service
@@ -5,7 +5,7 @@ PartOf=app-alpha.target
 User=app
 WorkingDirectory=/tmp/app
 Environment=PORT=%i
-ExecStart=/bin/bash -lc './alpha'
+ExecStart=/bin/bash -lc 'exec ./alpha'
 Restart=always
 StandardInput=null
 StandardOutput=syslog

--- a/spec/resources/export/systemd/app-bravo@.service
+++ b/spec/resources/export/systemd/app-bravo@.service
@@ -5,7 +5,7 @@ PartOf=app-bravo.target
 User=app
 WorkingDirectory=/tmp/app
 Environment=PORT=%i
-ExecStart=/bin/bash -lc './bravo'
+ExecStart=/bin/bash -lc 'exec ./bravo'
 Restart=always
 StandardInput=null
 StandardOutput=syslog


### PR DESCRIPTION
by prefixing the command with exec the current process image will be replaced with a new process image, so that the process correctly handles stop/restart/reload actions.

Tests are failing, and I probably can fix them, but my understanding of `exec` is not too thorough, so maybe someone with more knowledge can verify my understanding of how this works.

ref: https://github.com/influxdata/telegraf/pull/1279