### PR TITLE
Remove obsolete warning from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,17 @@ Manage Procfile-based applications
 
     $ gem install foreman
 
-Ruby users should take care *not* to install foreman in their project's `Gemfile`.
+Or add foreman to your Gemfile:
+
+```ruby
+group :development do
+  gem 'foreman', require: false
+end
+```
+
+and then run:
+
+    $ bundle install
 
 ## Getting Started
 


### PR DESCRIPTION
This is a fresh new try on #595. (I wondered about the reasons when reading that sentence in the README, and started looking through the issues/PRs mentioning the subject)

Credits to @panozzaj who did the original PR. @conf has also contributed to the discussion.