### PR TITLE
fixes #688: increases thor dependency to version 0.20.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     foreman (0.84.0)
-      thor (~> 0.19.1)
+      thor (~> 0.20.0)
 
 GEM
   remote: http://rubygems.org/
@@ -49,7 +49,7 @@ GEM
       json (~> 1.8)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.0)
-    thor (0.19.4)
+    thor (0.20.0)
     timecop (0.8.1)
     xml-simple (1.1.5)
     yard (0.8.7.6)
@@ -72,4 +72,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   1.13.7
+   1.15.4

--- a/foreman.gemspec
+++ b/foreman.gemspec
@@ -17,5 +17,5 @@ Gem::Specification.new do |gem|
   gem.files = Dir["**/*"].select { |d| d =~ %r{^(README|bin/|data/|ext/|lib/|spec/|test/)} }
   gem.files << "man/foreman.1"
 
-  gem.add_dependency 'thor', '~> 0.19.1'
+  gem.add_dependency 'thor', '~> 0.20.0'
 end


### PR DESCRIPTION
a fresh install of rails grabbed thor 0.20.0, adding foreman broke a bundle install unless thor was downgraded.