### PR TITLE
Add support for a PID file

### DIFF
--- a/lib/foreman/cli.rb
+++ b/lib/foreman/cli.rb
@@ -22,6 +22,7 @@ class Foreman::CLI < Thor
   method_option :color,     :type => :boolean, :aliases => "-c", :desc => "Force color to be enabled"
   method_option :env,       :type => :string,  :aliases => "-e", :desc => "Specify an environment file to load, defaults to .env"
   method_option :formation, :type => :string,  :aliases => "-m", :banner => '"alpha=5,bar=3"', :desc => 'Specify what processes will run and how many. Default: "all=1"'
+  method_option :pidfile,   :type => :string,                    :desc => "PID file for foreman process"
   method_option :port,      :type => :numeric, :aliases => "-p"
   method_option :timeout,   :type => :numeric, :aliases => "-t", :desc => "Specify the amount of time (in seconds) processes have to shutdown gracefully before receiving a SIGKILL, defaults to 5."
   method_option :timestamp, :type => :boolean, :default => true, :desc => "Include timestamp in output"

--- a/man/foreman.1
+++ b/man/foreman.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "FOREMAN" "1" "January 2017" "Foreman 0.84.0" "Foreman Manual"
+.TH "FOREMAN" "1" "September 2017" "Foreman 0.84.0" "Foreman Manual"
 .
 .SH "NAME"
 \fBforeman\fR \- manage Procfile\-based applications
@@ -37,6 +37,10 @@ Specify the number of each process type to run\. The value passed in should be i
 .TP
 \fB\-e\fR, \fB\-\-env\fR
 Specify one or more \.env files to load
+.
+.TP
+\fB\-\-pidfile\fR
+Specify a PID file to store the PID of the foreman process in\.
 .
 .TP
 \fB\-f\fR, \fB\-\-procfile\fR

--- a/man/foreman.1.ronn
+++ b/man/foreman.1.ronn
@@ -33,6 +33,9 @@ The following options control how the application is run:
   * `-e`, `--env`:
     Specify one or more .env files to load
 
+  * `--pidfile`:
+    Specify a PID file to store the PID of the foreman process in.
+
   * `-f`, `--procfile`:
     Specify an alternate Procfile to load, implies `-d` at the Procfile root.
 


### PR DESCRIPTION
This PR adds support for a PID file containing the PID of the foreman process. This makes it very easy to put a foreman process in the background and stop it when needed.

for example, you can do something like this:

`nohup foreman start --pidfile foreman.pid >/dev/null 2>&1 &`

and close the terminal which keeps the process running. You can then do `kill $(cat foreman.pid)` in a different terminal and the process will cleanly shut down