### PR TITLE
Fixed environment variable names being upcased

### DIFF
--- a/data/export/daemon/process.conf.erb
+++ b/data/export/daemon/process.conf.erb
@@ -3,6 +3,6 @@ stop on stopping <%= app %>-<%= name.gsub('_', '-') %>
 respawn
 
 env PORT=<%= port %><% engine.env.each_pair do |var, env| %>
-env <%= var.upcase %>=<%= env %><% end %>
+env <%= var %>=<%= env %><% end %>
 
 exec start-stop-daemon --start --chuid <%= user %> --chdir <%= engine.root %> --make-pidfile --pidfile <%= run %>/<%= app %>-<%= name %>-<%= num %>.pid --exec <%= executable %><%= arguments %> >> <%= log %>/<%= app %>-<%= name %>-<%= num %>.log 2>&1

--- a/data/export/launchd/launchd.plist.erb
+++ b/data/export/launchd/launchd.plist.erb
@@ -7,7 +7,7 @@
     <key>EnvironmentVariables</key>
     <dict>
     <%- engine.env.merge("PORT" => port).each_pair do |var,env| -%>
-        <key><%= var.upcase %></key>
+        <key><%= var %></key>
         <string><%= env %></string>
     <%- end -%>
     </dict>

--- a/data/export/systemd/process.service.erb
+++ b/data/export/systemd/process.service.erb
@@ -6,7 +6,7 @@ User=<%= user %>
 WorkingDirectory=<%= engine.root %>
 Environment=PORT=%i
 <% engine.env.each_pair do |var,env| -%>
-Environment="<%= var.upcase %>=<%= env %>"
+Environment="<%= var %>=<%= env %>"
 <% end -%>
 ExecStart=/bin/bash -lc 'exec <%= process.command %>'
 Restart=always

--- a/data/export/upstart/process.conf.erb
+++ b/data/export/upstart/process.conf.erb
@@ -5,7 +5,7 @@ respawn
 env PORT=<%= port %>
 <% engine.env.each do |name,value| -%>
 <% next if name.upcase == "PORT" -%>
-env <%= name.upcase %>='<%= value.gsub(/'/, "'\"'\"'") %>'
+env <%= name %>='<%= value.gsub(/'/, "'\"'\"'") %>'
 <% end -%>
 
 setuid <%= user %>


### PR DESCRIPTION
There are some environment variables (such as http_proxy, https_proxy, no_proxy etc) which are expected to be lower case. When these are upcased this causes some libraries (such as Net::HTTP) to not find the value expected.

I feel that the variables should be left as-is in the environment file provided during export to prevent any weird issues like this.