### PR TITLE
Use dotenv as a parser

### DIFF
--- a/foreman.gemspec
+++ b/foreman.gemspec
@@ -18,4 +18,5 @@ Gem::Specification.new do |gem|
   gem.files << "man/foreman.1"
 
   gem.add_dependency 'thor', '~> 0.19.1'
+  gem.add_dependency 'dotenv', '~> 2.0'
 end

--- a/lib/foreman/env.rb
+++ b/lib/foreman/env.rb
@@ -1,23 +1,12 @@
 require "foreman"
+require "dotenv"
 
 class Foreman::Env
 
   attr_reader :entries
 
   def initialize(filename)
-    @entries = File.read(filename).gsub("\r\n","\n").split("\n").inject({}) do |ax, line|
-      if line =~ /\A([A-Za-z_0-9]+)=(.*)\z/
-        key = $1
-        case val = $2
-          # Remove single quotes
-          when /\A'(.*)'\z/ then ax[key] = $1
-          # Remove double quotes and unescape string preserving newline characters
-          when /\A"(.*)"\z/ then ax[key] = $1.gsub('\n', "\n").gsub(/\\(.)/, '\1')
-         else ax[key] = val
-        end
-      end
-      ax
-    end
+    @entries = Dotenv::Parser.call(File.read(filename))
   end
 
   def entries


### PR DESCRIPTION
Hello maintainers :)
Thank you for developing this great gem!

I had a trouble with loading my .env file as it uses functionalities from dotenv gem.
Dotenv allows more powerful expressions in .env file than foreman does including command substitution, variable substitution, etc.
I edited the parser in foreman to use dotenv parser to fix the issue.

Could you please consider merging this PR?

Thank you!