### PR TITLE
Update thor gem from v0.19.x to v0.20.x

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     foreman (0.84.0)
-      thor (~> 0.19.1)
+      thor (~> 0.20.0)
 
 GEM
   remote: http://rubygems.org/
@@ -49,7 +49,7 @@ GEM
       json (~> 1.8)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.0)
-    thor (0.19.4)
+    thor (0.20.0)
     timecop (0.8.1)
     xml-simple (1.1.5)
     yard (0.9.12)

--- a/foreman.gemspec
+++ b/foreman.gemspec
@@ -17,5 +17,5 @@ Gem::Specification.new do |gem|
   gem.files = Dir["**/*"].select { |d| d =~ %r{^(README|bin/|data/|ext/|lib/|spec/|test/)} }
   gem.files << "man/foreman.1"
 
-  gem.add_dependency 'thor', '~> 0.19.1'
+  gem.add_dependency 'thor', '~> 0.20.0'
 end


### PR DESCRIPTION
Because other dependencies in our project require this version of [`thor`](https://github.com/erikhuda/thor).
