### PR TITLE
Adds export support

### DIFF
--- a/lib/foreman/env.rb
+++ b/lib/foreman/env.rb
@@ -1,22 +1,20 @@
 require "foreman"
 
+# Reads and exposes environment variables
+# from a .env file.
 class Foreman::Env
-
-  attr_reader :entries
-
   def initialize(filename)
-    @entries = File.read(filename).gsub("\r\n","\n").split("\n").inject({}) do |ax, line|
-      if line =~ /\A([A-Za-z_0-9]+)=(.*)\z/
-        key = $1
-        case val = $2
+    @entries = File.read(filename).gsub("\r\n", "\n").split("\n").each_with_object({}) do |line, ax|
+      next unless line =~ /\A([A-Za-z_0-9]+)=(.*)\z/
+      key = Regexp.last_match(1)
+      ax[key] =
+        case val = Regexp.last_match(2)
           # Remove single quotes
-          when /\A'(.*)'\z/ then ax[key] = $1
+        when /\A'(.*)'\z/ then Regexp.last_match(1)
           # Remove double quotes and unescape string preserving newline characters
-          when /\A"(.*)"\z/ then ax[key] = $1.gsub('\n', "\n").gsub(/\\(.)/, '\1')
-         else ax[key] = val
+        when /\A"(.*)"\z/ then Regexp.last_match(1).gsub('\n', "\n").gsub(/\\(.)/, '\1')
+        else val
         end
-      end
-      ax
     end
   end
 
@@ -25,5 +23,4 @@ class Foreman::Env
       yield key, value
     end
   end
-
 end

--- a/lib/foreman/env.rb
+++ b/lib/foreman/env.rb
@@ -3,9 +3,27 @@ require "foreman"
 # Reads and exposes environment variables
 # from a .env file.
 class Foreman::Env
+  LINE = /
+    \A
+    \s*
+    (?:export\s+)?    # optional export
+    ([\w\.]+)         # key
+    (?:\s*=\s*|:\s+?) # separator
+    (                 # optional value begin
+      '(?:\'|[^'])*'  #   single quoted value
+      |               #   or
+      "(?:\"|[^"])*"  #   double quoted value
+      |               #   or
+      [^#\n]+         #   unquoted value
+    )?                # value end
+    \s*
+    (?:\#.*)?         # optional comment
+    \z
+  /x
+
   def initialize(filename)
     @entries = File.read(filename).gsub("\r\n", "\n").split("\n").each_with_object({}) do |line, ax|
-      next unless line =~ /\A([A-Za-z_0-9]+)=(.*)\z/
+      next unless line =~ LINE
       key = Regexp.last_match(1)
       ax[key] =
         case val = Regexp.last_match(2)

--- a/lib/foreman/version.rb
+++ b/lib/foreman/version.rb
@@ -1,5 +1,5 @@
 module Foreman
 
-  VERSION = "0.82.0"
+  VERSION = "0.83.0"
 
 end

--- a/spec/foreman/engine_spec.rb
+++ b/spec/foreman/engine_spec.rb
@@ -109,6 +109,12 @@ describe "Foreman::Engine", :fakefs do
       subject.load_env "/tmp/env"
       expect(subject.send(:base_port)).to eq(9000)
     end
+
+    it "should handle an export prefix if specified" do
+      write_file("/tmp/env") { |f| f.puts("export FOO=bar") }
+      subject.load_env "/tmp/env"
+      expect(subject.env["FOO"]).to eq("bar")
+    end
   end
 
 end


### PR DESCRIPTION
### Context

Making and deploying some changes to .env config files I noticed that rendered templates didn't include some of the values in our .env file. This is problematic because we do use the same .env files to source environment configuration to run scripts/reports, etc.

This PR:
- [x] Submits a cheeky and small refactor
- [x] Adds an extended regex to support export prefixes (amongst other things).