### PR TITLE
Deprecate safe_level of ERB.new in Ruby 2.6

### DIFF
--- a/lib/foreman/export/base.rb
+++ b/lib/foreman/export/base.rb
@@ -135,7 +135,11 @@ private ######################################################################
   end
 
   def write_template(name, target, binding)
-    compiled = ERB.new(export_template(name), nil, '-').result(binding)
+    compiled = if ERB.instance_method(:initialize).parameters.assoc(:key) # Ruby 2.6+
+                 ERB.new(export_template(name), trim_mode: '-').result(binding)
+               else
+                 ERB.new(export_template(name), nil, '-').result(binding)
+               end
     write_file target, compiled
   end
 


### PR DESCRIPTION
The interface of `ERB.new` will change from Ruby 2.6.

> Add :trim_mode and :eoutvar keyword arguments to ERB.new.
> Now non-keyword arguments other than first one are softly deprecated
> and will be removed when Ruby 2.5 becomes EOL. [Feature #14256]

https://github.com/ruby/ruby/blob/2311087/NEWS#stdlib-updates-outstanding-ones-only