### PR TITLE
Fixes #709. Add Standard- and StandardError log configuration for SystemD

### DIFF
--- a/data/export/systemd/process.service.erb
+++ b/data/export/systemd/process.service.erb
@@ -11,8 +11,8 @@ Environment="<%= var %>=<%= env %>"
 ExecStart=/bin/bash -lc 'exec <%= process.command %>'
 Restart=always
 StandardInput=null
-StandardOutput=syslog
-StandardError=syslog
+StandardOutput=<%= log %>
+StandardError=<%= error_log %>
 SyslogIdentifier=%n
 KillMode=mixed
 TimeoutStopSec=<%= engine.options[:timeout] %>

--- a/lib/foreman/export/systemd.rb
+++ b/lib/foreman/export/systemd.rb
@@ -37,4 +37,12 @@ class Foreman::Export::Systemd < Foreman::Export::Base
 
     write_template "systemd/master.target.erb", "#{app}.target", binding
   end
+
+  def log
+    options[:log] || "syslog"
+  end
+
+  def error_log
+    options[:error_log] || "syslog"
+  end
 end

--- a/spec/foreman/export/systemd_spec.rb
+++ b/spec/foreman/export/systemd_spec.rb
@@ -66,6 +66,24 @@ describe Foreman::Export::Systemd, :fakefs do
     expect(File.read("/tmp/init/app-alpha@.service")).to match(/^ExecStart=/)
   end
 
+  context "with a log setting" do
+    it "includes StandardOutput line with default value" do
+      systemd.export
+      expect(File.read("/tmp/init/app-alpha@.service")).to match("StandardOutput=syslog")
+      expect(File.read("/tmp/init/app-alpha@.service")).to match("StandardError=syslog")
+    end
+
+    context "with custom options" do
+      let(:options) { { :log => "/var/log/app-alpha", :error_log => "/var/log/app-alpha_error" } }
+
+      it "includes StandardOutput line with given value" do
+        systemd.export
+        expect(File.read("/tmp/init/app-alpha@.service")).to match("StandardOutput=/var/log/app-alpha")
+        expect(File.read("/tmp/init/app-alpha@.service")).to match("StandardError=/var/log/app-alpha_error")
+      end
+    end
+  end
+
   context "with a formation" do
     let(:formation) { "alpha=2" }
 


### PR DESCRIPTION
I've added options to configure the log entries for the systemd configuration. 
I overwrote the export defaults in the SystemD class, to keep the behaviour of writing to syslog the same as before (before, syslog was called explicit in the systemd files directly) - so it should not break the default behaviour from before.

I also added 2 tests which pass fine. 
Feel free to comment and merge, if everything is fine :) 

Hope this PR is fine, it's my first one for this project :)