### PR TITLE
Add psych gem to gemspec

### DIFF
--- a/foreman.gemspec
+++ b/foreman.gemspec
@@ -18,4 +18,5 @@ Gem::Specification.new do |gem|
   gem.files << "man/foreman.1"
 
   gem.add_dependency 'thor', '~> 0.19.1'
+  gem.add_dependency 'psych'
 end


### PR DESCRIPTION
# Problem

We're using formeman in a project, and one of our users had trouble getting (the script that calls) foreman to start properly.  It seems the problem was the psych gem was not installed.

```
$ bin/foreman-start.sh 
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:--  0:00:29 --:--:--     0curl: (6) Could not resolve host: mirrors.gigenet.com
/usr/local/Cellar/ruby/2.4.1_1/lib/ruby/2.4.0/yaml.rb:5:in `<top (required)>':
It seems your ruby installation is missing psych (for YAML output).
```
# Solution

Including the psych gem in gemspec.  This is a defensive coding option.  Normally I wouldn't recommend including a dependency that isn't directly consumed by the application.  However, in this case, psych should be included in Ruby installs anyway, so including it in foreman seems like an appropriate solution.

```
$ asdf install ruby 2.5.0
$ asdf shell ruby 2.5.0
$ gem list | grep psych
psych (default: 3.0.2)
```