### PR TITLE
Relax Thor dependency

### DIFF
--- a/foreman.gemspec
+++ b/foreman.gemspec
@@ -17,5 +17,5 @@ Gem::Specification.new do |gem|
   gem.files = Dir["**/*"].select { |d| d =~ %r{^(README|bin/|data/|ext/|lib/|spec/|test/)} }
   gem.files << "man/foreman.1"
 
-  gem.add_dependency 'thor', '~> 0.19.1'
+  gem.add_dependency 'thor', '>= 0.19.1'
 end


### PR DESCRIPTION
Rails 6 depends upon Thor `>= 0.20.3, < 2.0` so this makes it compatible with both older and newer versions.