### PR TITLE
update thor to v0.20

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ language: ruby
 sudo: false
 
 before_install:
-  - gem install "rubygems-update:<3.0.0" --no-document
-  - update_rubygems
   - gem update --system
   - gem install bundler
 
@@ -16,7 +14,6 @@ cache: bundler
 bundler_args: --without development
 
 rvm:
-  - 2.2.10
   - 2.3.7
   - 2.4.4
   - 2.5.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ language: ruby
 sudo: false
 
 before_install:
+  - gem install "rubygems-update:<3.0.0" --no-document
+  - update_rubygems
   - gem update --system
   - gem install bundler
 
@@ -14,10 +16,10 @@ cache: bundler
 bundler_args: --without development
 
 rvm:
-- 2.2.10
-- 2.3.7
-- 2.4.4
-- 2.5.1
+  - 2.2.10
+  - 2.3.7
+  - 2.4.4
+  - 2.5.1
 env:
   global:
     secure: IKoaAfTsrU1scmRO7LNJ+hVGzVeYrCB8qwr1KK/WiCm6JirAhiwvpf7osaMT6h+QRELSiAay2wPn89FqpZ9wzpL/zh5kpgfI04gnKrD7ZlPiKDPYddt6R4+Z4+LUZ0dkoM//MjRiIKz0wdvgbzn/E8FSpuhh3FeVYzYVTmAfgME=

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     foreman (0.85.0)
-      thor (~> 0.19.1)
+      thor (~> 0.20)
 
 GEM
   remote: http://rubygems.org/
@@ -49,7 +49,7 @@ GEM
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
-    thor (0.19.4)
+    thor (0.20.3)
     timecop (0.9.1)
     xml-simple (1.1.5)
     yard (0.9.12)
@@ -72,4 +72,4 @@ DEPENDENCIES
   yard (~> 0.9.11)
 
 BUNDLED WITH
-   1.16.1
+   1.17.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     foreman (0.85.0)
-      thor (~> 0.20)
+      thor (>= 0.19, < 0.21)
 
 GEM
   remote: http://rubygems.org/

--- a/foreman.gemspec
+++ b/foreman.gemspec
@@ -17,5 +17,5 @@ Gem::Specification.new do |gem|
   gem.files = Dir["**/*"].select { |d| d =~ %r{^(README|bin/|data/|ext/|lib/|spec/|test/)} }
   gem.files << "man/foreman.1"
 
-  gem.add_dependency 'thor', '~> 0.19.1'
+  gem.add_dependency 'thor', '~> 0.20'
 end

--- a/foreman.gemspec
+++ b/foreman.gemspec
@@ -17,5 +17,5 @@ Gem::Specification.new do |gem|
   gem.files = Dir["**/*"].select { |d| d =~ %r{^(README|bin/|data/|ext/|lib/|spec/|test/)} }
   gem.files << "man/foreman.1"
 
-  gem.add_dependency 'thor', '~> 0.20'
+  gem.add_dependency "thor", ">= 0.19", "< 0.21"
 end


### PR DESCRIPTION
I would like to use a [gem](https://github.com/dvmonroe/release-notes) in my project but it requires `thor (~> 0.20)`, which results in the following error:
```
Bundler could not find compatible versions for gem "thor":                                                                                                                      
  In snapshot (Gemfile.lock):                                                                                                                                                   
    thor (= 0.19.4)                                                                                                                                                             
                                                                                                                                                                                
  In Gemfile:                                                                                                                                                                   
    foreman was resolved to 0.85.0, which depends on                                                                                                                            
      thor (~> 0.19.1)                                                                                                                                                          
                                                                                                                                                                                
    release-notes (~> 4.0) was resolved to 4.0.0, which depends on                                                                                                              
      thor (~> 0.20)                                                                                                                                                            
                                                                                                                                                                                
Running `bundle update` will rebuild your snapshot from scratch, using only                                                                                                     
the gems in your Gemfile, which may resolve the conflict.
```

I took a look and did not see any reason why foreman could not be bumped to v0.20 so this PR does exactly that. 