### PR TITLE
Relax thor dependency

### DIFF
--- a/foreman.gemspec
+++ b/foreman.gemspec
@@ -17,5 +17,5 @@ Gem::Specification.new do |gem|
   gem.files = Dir["**/*"].select { |d| d =~ %r{^(README|bin/|data/|ext/|lib/|spec/|test/)} }
   gem.files << "man/foreman.1"
 
-  gem.add_dependency 'thor', '~> 0.19.1'
+  gem.add_dependency 'thor', '~> 0.19.1', '< 2.0'
 end


### PR DESCRIPTION
I chose to relax it to `< 2.0` because that's what Rails is set to but if you want this less relaxed let me know and I'll update. Thank you!

---

Rails 6.0 Railties requires thor set to
`s.add_dependency "thor", ">= 0.20.3", "< 2.0"` and currently foreman
won't allow anything higher than 0.19.x. See https://github.com/rails/rails/blob/master/railties/railties.gemspec#L40

This PR relaxes the thor dependency so that foreman can be used with
applications running or upgrading to Rails 6+

cc/ @ddollar 