### PR TITLE
CI: Use 2.4.6, 2.5.5, 2.6.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: ruby
 
-sudo: false
-
 before_install:
   - gem update --system
   - gem install bundler
@@ -14,10 +12,10 @@ cache: bundler
 bundler_args: --without development
 
 rvm:
-- 2.2.10
-- 2.3.7
-- 2.4.4
-- 2.5.1
+- 2.3.8
+- 2.4.6
+- 2.5.5
+- 2.6.3
 env:
   global:
     secure: IKoaAfTsrU1scmRO7LNJ+hVGzVeYrCB8qwr1KK/WiCm6JirAhiwvpf7osaMT6h+QRELSiAay2wPn89FqpZ9wzpL/zh5kpgfI04gnKrD7ZlPiKDPYddt6R4+Z4+LUZ0dkoM//MjRiIKz0wdvgbzn/E8FSpuhh3FeVYzYVTmAfgME=


### PR DESCRIPTION
This PR updates the CI matrix to the latest generally available Ruby versions.

Ruby 2.3 was recently EOL'd, and could _also_ be dropped from the matrix.

---

  - Also: The Travis setting sudo: false has been removed - See https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration