### PR TITLE
Allow supervisord environment vars to have "+"

### DIFF
--- a/data/export/supervisord/app.conf.erb
+++ b/data/export/supervisord/app.conf.erb
@@ -9,6 +9,7 @@ engine.each_process do |name, process|
     	value = value.gsub('\=', '=')
     	value = value.gsub('\&', '&')
     	value = value.gsub('\?', '?')
+    	value = value.gsub('\+', '+')
       "#{key}=\"#{value}\""
     end
     app_names << full_name

--- a/spec/foreman/engine_spec.rb
+++ b/spec/foreman/engine_spec.rb
@@ -83,6 +83,7 @@ describe "Foreman::Engine", :fakefs do
         f.puts "FRED='barney'"
         f.puts 'OTHER="escaped\"quote"'
         f.puts 'URL="http://example.com/api?foo=bar&baz=1"'
+        f.puts 'KEY="LkZAMKGHwA9MsLj+rIVLmSMg+p206CeNaliqyFrjt9"'
       end
       subject.load_env "/tmp/env"
       expect(subject.env["FOO"]).to   eq("bar")
@@ -90,6 +91,7 @@ describe "Foreman::Engine", :fakefs do
       expect(subject.env["FRED"]).to  eq("barney")
       expect(subject.env["OTHER"]).to eq('escaped"quote')
       expect(subject.env["URL"]).to   eq("http://example.com/api?foo=bar&baz=1")
+      expect(subject.env["KEY"]).to   eq("LkZAMKGHwA9MsLj+rIVLmSMg+p206CeNaliqyFrjt9")
     end
 
     it "should handle multiline strings" do

--- a/spec/foreman/export/supervisord_spec.rb
+++ b/spec/foreman/export/supervisord_spec.rb
@@ -14,7 +14,7 @@ describe Foreman::Export::Supervisord, :fakefs do
   before(:each) { allow(supervisord).to receive(:say) }
 
   it "exports to the filesystem" do
-    write_env(".env", "FOO"=>"bar", "URL"=>"http://example.com/api?foo=bar&baz=1")
+    write_env(".env", "FOO"=>"bar", "URL"=>"http://example.com/api?foo=bar&baz=1", "KEY"=>"LkZAMKGHwA9MsLj+rIVLmSMg+p206CeNaliqyFrjt9")
     supervisord.engine.load_env('.env')
     supervisord.export
     expect(File.read("/tmp/init/app.conf")).to eq(example_export_file("supervisord/app-alpha-1.conf"))

--- a/spec/resources/export/supervisord/app-alpha-1.conf
+++ b/spec/resources/export/supervisord/app-alpha-1.conf
@@ -6,7 +6,7 @@ stdout_logfile=/var/log/app/alpha-1.log
 stderr_logfile=/var/log/app/alpha-1.error.log
 user=app
 directory=/tmp/app
-environment=FOO="bar",URL="http://example.com/api?foo=bar&baz=1",PORT="5000"
+environment=FOO="bar",URL="http://example.com/api?foo=bar&baz=1",KEY="LkZAMKGHwA9MsLj+rIVLmSMg+p206CeNaliqyFrjt9",PORT="5000"
 
 [program:app-bravo-1]
 command=./bravo
@@ -16,7 +16,7 @@ stdout_logfile=/var/log/app/bravo-1.log
 stderr_logfile=/var/log/app/bravo-1.error.log
 user=app
 directory=/tmp/app
-environment=FOO="bar",URL="http://example.com/api?foo=bar&baz=1",PORT="5100"
+environment=FOO="bar",URL="http://example.com/api?foo=bar&baz=1",KEY="LkZAMKGHwA9MsLj+rIVLmSMg+p206CeNaliqyFrjt9",PORT="5100"
 
 [program:app-foo_bar-1]
 command=./foo_bar
@@ -26,7 +26,7 @@ stdout_logfile=/var/log/app/foo_bar-1.log
 stderr_logfile=/var/log/app/foo_bar-1.error.log
 user=app
 directory=/tmp/app
-environment=FOO="bar",URL="http://example.com/api?foo=bar&baz=1",PORT="5200"
+environment=FOO="bar",URL="http://example.com/api?foo=bar&baz=1",KEY="LkZAMKGHwA9MsLj+rIVLmSMg+p206CeNaliqyFrjt9",PORT="5200"
 
 [program:app-foo-bar-1]
 command=./foo-bar
@@ -36,7 +36,7 @@ stdout_logfile=/var/log/app/foo-bar-1.log
 stderr_logfile=/var/log/app/foo-bar-1.error.log
 user=app
 directory=/tmp/app
-environment=FOO="bar",URL="http://example.com/api?foo=bar&baz=1",PORT="5300"
+environment=FOO="bar",URL="http://example.com/api?foo=bar&baz=1",KEY="LkZAMKGHwA9MsLj+rIVLmSMg+p206CeNaliqyFrjt9",PORT="5300"
 
 [group:app]
 programs=app-alpha-1,app-bravo-1,app-foo_bar-1,app-foo-bar-1


### PR DESCRIPTION
There could be environment variables with a "+" (e.g. a public key). The + should not get escaped, else the content of the environment variable is wrong.

I did the changes in the same way like it was done for "=", "?" and "&" in #572