### PR TITLE
Update thor to v 0.20

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     foreman (0.85.0)
-      thor (~> 0.19.1)
+      thor (~> 0.20)
 
 GEM
   remote: http://rubygems.org/
@@ -49,7 +49,7 @@ GEM
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
-    thor (0.19.4)
+    thor (0.20.3)
     timecop (0.9.1)
     xml-simple (1.1.5)
     yard (0.9.20)

--- a/foreman.gemspec
+++ b/foreman.gemspec
@@ -17,5 +17,5 @@ Gem::Specification.new do |gem|
   gem.files = Dir["**/*"].select { |d| d =~ %r{^(README|bin/|data/|ext/|lib/|spec/|test/)} }
   gem.files << "man/foreman.1"
 
-  gem.add_dependency 'thor', '~> 0.19.1'
+  gem.add_dependency 'thor', '~> 0.20'
 end


### PR DESCRIPTION
This fix will help to install us some other gem (karafka) depends on thor 0.20 and have working system uses both that gem and foreman.

Use for ref - https://github.com/karafka/karafka/commit/e96a3bcc3ac17bc07eb7f6ba1145d77c1e77b944#diff-43cf19fcc0befb2ed6a30376a6d0f3a3