### PR TITLE
CI: Use ruby 2.5.6, 2.6.4 in the matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,8 @@ bundler_args: --without development
 rvm:
 - 2.3.8
 - 2.4.6
-- 2.5.5
-- 2.6.3
+- 2.5.6
+- 2.6.4
 env:
   global:
     secure: IKoaAfTsrU1scmRO7LNJ+hVGzVeYrCB8qwr1KK/WiCm6JirAhiwvpf7osaMT6h+QRELSiAay2wPn89FqpZ9wzpL/zh5kpgfI04gnKrD7ZlPiKDPYddt6R4+Z4+LUZ0dkoM//MjRiIKz0wdvgbzn/E8FSpuhh3FeVYzYVTmAfgME=


### PR DESCRIPTION
This updates the CI matrix.

(The only reason I didn't include 2.4.7, is that I've yet to see it work installing - the rvm installation has just 404'd, for _that_ version only.)