### PR TITLE
Update thor to version `~> 0.20.0`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     foreman (0.85.0)
-      thor (~> 0.19.1)
+      thor (~> 0.20.0)
 
 GEM
   remote: http://rubygems.org/
@@ -49,7 +49,7 @@ GEM
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
-    thor (0.19.4)
+    thor (0.20.3)
     timecop (0.9.1)
     xml-simple (1.1.5)
     yard (0.9.20)

--- a/foreman.gemspec
+++ b/foreman.gemspec
@@ -17,5 +17,5 @@ Gem::Specification.new do |gem|
   gem.files = Dir["**/*"].select { |d| d =~ %r{^(README|bin/|data/|ext/|lib/|spec/|test/)} }
   gem.files << "man/foreman.1"
 
-  gem.add_dependency 'thor', '~> 0.19.1'
+  gem.add_dependency 'thor', '~> 0.20.0'
 end


### PR DESCRIPTION
Permits to use foreman with `rails (~> 6.0)`. The last version of rails released a couple of weeks ago requires `thor (>= 0.20.3, < 2.0)`

```
Bundler could not find compatible versions for gem "thor":
  In Gemfile:
    foreman was resolved to 0.85.0, which depends on
      thor (~> 0.19.1)

    rails (~> 6.0) was resolved to 6.0.0, which depends on
      railties (= 6.0.0) was resolved to 6.0.0, which depends on
        thor (>= 0.20.3, < 2.0)
```