### PR TITLE
Systemd export: provide $PS to processes, no longer use systemd templates

### DIFF
--- a/data/export/systemd/master.target.erb
+++ b/data/export/systemd/master.target.erb
@@ -1,5 +1,5 @@
 [Unit]
-Wants=<%= process_master_names.join(' ') %>
+Wants=<%= service_names.join(' ') %>
 
 [Install]
 WantedBy=multi-user.target

--- a/data/export/systemd/process.service.erb
+++ b/data/export/systemd/process.service.erb
@@ -1,14 +1,15 @@
 [Unit]
-PartOf=<%= app %>-<%= name %>.target
+PartOf=<%= app %>.target
 
 [Service]
 User=<%= user %>
 WorkingDirectory=<%= engine.root %>
-Environment=PORT=%i
+Environment=PORT=<%= port %>
+Environment=PS=<%= process_name %>
 <% engine.env.each_pair do |var,env| -%>
 Environment="<%= var %>=<%= env %>"
 <% end -%>
-ExecStart=/bin/bash -lc 'exec <%= process.command %>'
+ExecStart=/bin/bash -lc 'exec -a "<%= app %>-<%= process_name %>" <%= process.command %>'
 Restart=always
 StandardInput=null
 StandardOutput=syslog

--- a/data/export/systemd/process.service.erb
+++ b/data/export/systemd/process.service.erb
@@ -1,5 +1,6 @@
 [Unit]
 PartOf=<%= app %>.target
+StopWhenUnneeded=yes
 
 [Service]
 User=<%= user %>

--- a/data/export/systemd/process.service.erb
+++ b/data/export/systemd/process.service.erb
@@ -11,6 +11,7 @@ Environment="<%= var %>=<%= env %>"
 <% end -%>
 ExecStart=/bin/bash -lc 'exec -a "<%= app %>-<%= process_name %>" <%= process.command %>'
 Restart=always
+RestartSec=14s
 StandardInput=null
 StandardOutput=syslog
 StandardError=syslog

--- a/data/export/systemd/process_master.target.erb
+++ b/data/export/systemd/process_master.target.erb
@@ -1,2 +1,0 @@
-[Unit]
-PartOf=<%= app %>.target

--- a/lib/foreman/export/systemd.rb
+++ b/lib/foreman/export/systemd.rb
@@ -17,22 +17,16 @@ class Foreman::Export::Systemd < Foreman::Export::Base
       clean_dir file
     end
 
-    process_master_names = []
+    service_names = []
 
     engine.each_process do |name, process|
-      service_fn = "#{app}-#{name}@.service"
-      write_template "systemd/process.service.erb", service_fn, binding
-
-      create_directory("#{app}-#{name}.target.wants")
-      1.upto(engine.formation[name])
-        .collect { |num| engine.port_for(process, num) }
-        .collect { |port| "#{app}-#{name}@#{port}.service" }
-        .each do |process_name|
-        create_symlink("#{app}-#{name}.target.wants/#{process_name}", "../#{service_fn}") rescue Errno::EEXIST # This is needed because rr-mocks do not call the origial cleanup
+      1.upto(engine.formation[name]) do |num|
+        port = engine.port_for(process, num)
+        process_name = "#{name}.#{num}"
+        service_filename = "#{app}-#{process_name}.service"
+        write_template "systemd/process.service.erb", service_filename, binding
+        service_names << service_filename
       end
-
-      write_template "systemd/process_master.target.erb", "#{app}-#{name}.target", binding
-      process_master_names << "#{app}-#{name}.target"
     end
 
     write_template "systemd/master.target.erb", "#{app}.target", binding

--- a/spec/resources/export/systemd/app-alpha.1.service
+++ b/spec/resources/export/systemd/app-alpha.1.service
@@ -1,12 +1,15 @@
 [Unit]
-PartOf=app-alpha.target
+PartOf=app.target
+StopWhenUnneeded=yes
 
 [Service]
 User=app
 WorkingDirectory=/tmp/app
-Environment=PORT=%i
-ExecStart=/bin/bash -lc 'exec ./alpha'
+Environment=PORT=5000
+Environment=PS=alpha.1
+ExecStart=/bin/bash -lc 'exec -a "app-alpha.1" ./alpha'
 Restart=always
+RestartSec=14s
 StandardInput=null
 StandardOutput=syslog
 StandardError=syslog

--- a/spec/resources/export/systemd/app-alpha.2.service
+++ b/spec/resources/export/systemd/app-alpha.2.service
@@ -1,12 +1,15 @@
 [Unit]
-PartOf=app-bravo.target
+PartOf=app.target
+StopWhenUnneeded=yes
 
 [Service]
 User=app
 WorkingDirectory=/tmp/app
-Environment=PORT=%i
-ExecStart=/bin/bash -lc 'exec ./bravo'
+Environment=PORT=5001
+Environment=PS=alpha.2
+ExecStart=/bin/bash -lc 'exec -a "app-alpha.2" ./alpha'
 Restart=always
+RestartSec=14s
 StandardInput=null
 StandardOutput=syslog
 StandardError=syslog

--- a/spec/resources/export/systemd/app-bravo.1.service
+++ b/spec/resources/export/systemd/app-bravo.1.service
@@ -1,0 +1,18 @@
+[Unit]
+PartOf=app.target
+StopWhenUnneeded=yes
+
+[Service]
+User=app
+WorkingDirectory=/tmp/app
+Environment=PORT=5100
+Environment=PS=bravo.1
+ExecStart=/bin/bash -lc 'exec -a "app-bravo.1" ./bravo'
+Restart=always
+RestartSec=14s
+StandardInput=null
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier=%n
+KillMode=mixed
+TimeoutStopSec=5

--- a/spec/resources/export/systemd/app.target
+++ b/spec/resources/export/systemd/app.target
@@ -1,5 +1,5 @@
 [Unit]
-Wants=app-alpha.target app-bravo.target app-foo_bar.target app-foo-bar.target
+Wants=app-alpha.1.service app-bravo.1.service app-foo_bar.1.service app-foo-bar.1.service
 
 [Install]
 WantedBy=multi-user.target

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -105,7 +105,7 @@ end
 def write_file(file)
   FileUtils.mkdir_p(File.dirname(file))
   File.open(file, 'w') do |f|
-    yield(f)
+    yield(f) if block_given?
   end
 end
 


### PR DESCRIPTION
The systemd export implementation was designed using systemd templates. When system templates are instantiated, the only piece of information that could be given to an instantiated instance is a single string coming after the "@", which as currently implemented is the port number.

Port numbers as part of the service name are not useful for humans or for scripting because they change when the process formation changes—they're assigned sequentially when each service is exported, so there's no continuity between exports if the formation is changed.

When foreman is run directly, it provides a `$PS` environment variable that can be used within the Procfile and within each process, to allow the process to be identified in the context of the app. This is in the form "(process_name).num" and is used standardly throughout foreman (for example when logging).

By removing the use of systemd templates, each generated systemd service gets a full service file that can have multiple pieces of information included. The `$PORT` and `$PS` environment variables are set within the file.

Syslog will continue to receive the full service name, but the service name is now "(app_name)-(process_name).(index)" instead of "(app_name)-(process_name)@(port)". These are the names used when controlling the services (e.g. `systemctl stop myapp-sidekiq.1.service`).

In addition, a change was made to allow all of the services to be controlled as a group using the app target. This was done by adding `StopWhenUnneeded=yes` to each service as [documented here](https://www.freedesktop.org/software/systemd/man/systemd.unit.html#StopWhenUnneeded=). So the commands `systemctl start myapp.target` and `systemctl stop myapp.target` will start and stop the entire formation.

While the app target that is exported is configured to be wanted by the multi-user target, that doesn't take effect unless the target is enabled. So to cause the app services to be started automatically on system start, the command `systemctl enable myapp.target` must be issued once after foreman has exported.

This is a breaking change, so anyone using systemd export will need to be aware of this. I'm not sure how to approach backward compatibility with this. One possibility is to preserve the existing systemd export method as-is and rename my new method to something else like "systemd2".
