### PR TITLE
Add project metadata to the gemspec

### DIFF
--- a/foreman.gemspec
+++ b/foreman.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.metadata = {
     "bug_tracker_uri" => "#{gem.homepage}/issues",
     "changelog_uri" => "#{gem.homepage}/blob/master/Changelog.md",
-    "documentation_uri" => "https://rubydoc.info/gems/#{gem.name}/#{gem.version}",
+    "documentation_uri" => "https://ddollar.github.io/foreman/",
     "homepage_uri" => gem.homepage,
     "source_code_uri" => "#{gem.homepage}/tree/v#{gem.version}",
     "wiki_uri" => "#{gem.homepage}/wiki"

--- a/foreman.gemspec
+++ b/foreman.gemspec
@@ -13,6 +13,15 @@ Gem::Specification.new do |gem|
 
   gem.description = gem.summary
 
+  gem.metadata = {
+    "bug_tracker_uri" => "#{gem.homepage}/issues",
+    "changelog_uri" => "#{gem.homepage}/blob/master/Changelog.md",
+    "documentation_uri" => "https://rubydoc.info/gems/#{gem.name}/#{gem.version}",
+    "homepage_uri" => gem.homepage,
+    "source_code_uri" => "#{gem.homepage}/tree/v#{gem.version}",
+    "wiki_uri" => "#{gem.homepage}/wiki"
+  }
+
   gem.executables = "foreman"
   gem.files = Dir["**/*"].select { |d| d =~ %r{^(README|bin/|data/|ext/|lib/|spec/|test/)} }
   gem.files << "man/foreman.1"

--- a/foreman.gemspec
+++ b/foreman.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |gem|
 
   gem.author   = "David Dollar"
   gem.email    = "ddollar@gmail.com"
-  gem.homepage = "http://github.com/ddollar/foreman"
+  gem.homepage = "https://github.com/ddollar/foreman"
   gem.summary  = "Process manager for applications with multiple components"
 
   gem.description = gem.summary


### PR DESCRIPTION
Add `bug_tracker_uri`, `changelog_uri`, `documentation_uri`, `homepage_uri`, `source_code_uri`, and `wiki_uri` to the gemspec metadata.

These [project metadata](https://guides.rubygems.org/specification-reference/#metadata) will facilitate easy access to project information. The URI will be available on the [Rubygems project page](https://rubygems.org/gems/foreman), via the rubygems API, and the `gem` and `bundle` command-line tools with the next release.