### PR TITLE
[Foreman::Procfile#load] Fail when empty

### DIFF
--- a/lib/foreman/cli.rb
+++ b/lib/foreman/cli.rb
@@ -69,8 +69,9 @@ class Foreman::CLI < Foreman::Thor
   def check
     check_procfile!
     engine.load_procfile(procfile)
-    error "no processes defined" unless engine.processes.length > 0
     puts "valid procfile detected (#{engine.process_names.join(', ')})"
+  rescue Foreman::Procfile::EmptyFileError
+    error "no processes defined"
   end
 
   desc "run COMMAND [ARGS...]", "Run a command using your application's environment"

--- a/lib/foreman/procfile.rb
+++ b/lib/foreman/procfile.rb
@@ -10,6 +10,8 @@ require "foreman"
 #
 class Foreman::Procfile
 
+  EmptyFileError = Class.new(StandardError)
+
   # Initialize a Procfile
   #
   # @param [String] filename (nil)  An optional filename to read from
@@ -60,7 +62,11 @@ class Foreman::Procfile
   # @param [String] filename  The filename of the +Procfile+ to load
   #
   def load(filename)
-    @entries.replace parse(filename)
+    parse_data = parse(filename)
+
+    raise EmptyFileError if parse_data.empty?
+
+    @entries.replace parse_data
   end
 
   # Save a Procfile to a file

--- a/spec/foreman/procfile_spec.rb
+++ b/spec/foreman/procfile_spec.rb
@@ -22,6 +22,14 @@ describe Foreman::Procfile, :fakefs do
     expect(procfile["foo_bar"]).to eq("./foo_bar")
   end
 
+  it "raises an error if Procfile is empty" do
+    write_file "Procfile" do |procfile|
+      procfile.puts
+    end
+
+    expect { Foreman::Procfile.new("Procfile") }.to raise_error described_class::EmptyFileError
+  end
+
   it 'only creates Procfile entries for lines matching regex' do
     write_procfile
     procfile = Foreman::Procfile.new("Procfile")


### PR DESCRIPTION
Followup to https://github.com/ddollar/foreman/pull/769

Includes logic to cause loading an empty `Procfile` to raise a `Foreman::Procfile::EmptyFileError`.

Keeps existing logic/error message for `foreman check`, just rescues this new error when doing so.