### PR TITLE
[spec_helper.rb] Error when Procfile present

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,12 @@
 # require "codeclimate-test-reporter"
 # CodeClimate::TestReporter.start
 
+raise <<-ERROR if File.exist?(File.expand_path("../../Procfile", __FILE__))
+Procfile detected in home directory for foreman repo.  Please delete/move the
+file before attempting to run the specs as there are specs that depend on that
+file not existing.
+ERROR
+
 require "simplecov"
 SimpleCov.start do
   add_filter "/spec/"


### PR DESCRIPTION
While developing specs for https://github.com/ddollar/foreman/pull/770 I ran into this scenario (only a problem currently with those changes from #770 in place and a empty Procfile present).


Issue
-----

With a present and empty `Procfile` in the root directory of the project, this has the potential to cause specs in `cli_spec.rb` to fail in a non-obvious way, and is not simple to debug the root cause.

Because of how `forked_foreman` is implemented, it doesn't included the `FakeFs` context to the subprocess, so it is pretty hard to deduce that it is running outside of that context, and that any generated `Procfile` (using `write_procfile` for example) will not be visible to the sub process.

To avoid this confusion and errors that might be caused from this, this error is in place to warn the user if the file currently exists and prevents running the specs with it in place.