### PR TITLE
GitHub is HTTPS by default

### DIFF
--- a/foreman.gemspec
+++ b/foreman.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |gem|
 
   gem.author   = "David Dollar"
   gem.email    = "ddollar@gmail.com"
-  gem.homepage = "http://github.com/ddollar/foreman"
+  gem.homepage = "https://github.com/ddollar/foreman"
   gem.summary  = "Process manager for applications with multiple components"
 
   gem.description = gem.summary


### PR DESCRIPTION
This reduces unnecessary redirection from http://... to https://... when someone visits this gem's homepage via https://rubygems.org/gems/foreman or some tools or APIs that use the gem's metadata.