### PR TITLE
spec_helper: don't try to remove /tmp

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -181,7 +181,4 @@ RSpec.configure do |config|
   config.before(:each) do
     FileUtils.mkdir_p('/tmp')
   end
-  config.after(:each) do
-    FileUtils.rm_rf('/tmp')
-  end
 end


### PR DESCRIPTION
The FakeFS spec helper already cleans up the filesystem after each test.
Also, that after helper is executed after FakeFS already deactivated
itself, so in some systems, that can cause the real /tmp to be removed
if the user running the tests has permissions to do so.