### PR TITLE
Rename usage of Dir/File.exists to exist

### DIFF
--- a/lib/foreman/export/base.rb
+++ b/lib/foreman/export/base.rb
@@ -83,7 +83,7 @@ private ######################################################################
   def chown user, dir
     FileUtils.chown user, nil, dir
   rescue
-    error("Could not chown #{dir} to #{user}") unless File.writable?(dir) || ! File.exists?(dir)
+    error("Could not chown #{dir} to #{user}") unless File.writable?(dir) || ! File.exist?(dir)
   end
 
   def error(message)
@@ -95,13 +95,13 @@ private ######################################################################
   end
   
   def clean(filename)
-    return unless File.exists?(filename)
+    return unless File.exist?(filename)
     say "cleaning up: #{filename}"
     FileUtils.rm(filename)
   end
 
   def clean_dir(dirname)
-    return unless File.exists?(dirname)
+    return unless File.exist?(dirname)
     say "cleaning up directory: #{dirname}"
     FileUtils.rm_r(dirname)
   end
@@ -130,7 +130,7 @@ private ######################################################################
       matchers << File.join(options[:template], name_without_first) if options[:template]
       matchers << File.expand_path("~/.foreman/templates/#{name}")
       matchers << File.expand_path("../../../../data/export/#{name}", __FILE__)
-      File.read(matchers.detect { |m| File.exists?(m) })
+      File.read(matchers.detect { |m| File.exist?(m) })
     end
   end
 

--- a/spec/foreman/export/daemon_spec.rb
+++ b/spec/foreman/export/daemon_spec.rb
@@ -60,7 +60,7 @@ describe Foreman::Export::Daemon, :fakefs do
       expect(File.read("/tmp/init/app-alpha.conf")).to      eq(example_export_file("daemon/app-alpha.conf"))
       expect(File.read("/tmp/init/app-alpha-1.conf")).to    eq(example_export_file("daemon/app-alpha-1.conf"))
       expect(File.read("/tmp/init/app-alpha-2.conf")).to    eq(example_export_file("daemon/app-alpha-2.conf"))
-      expect(File.exists?("/tmp/init/app-bravo-1.conf")).to eq(false)
+      expect(File.exist?("/tmp/init/app-bravo-1.conf")).to eq(false)
     end
   end
 

--- a/spec/foreman/export/upstart_spec.rb
+++ b/spec/foreman/export/upstart_spec.rb
@@ -81,7 +81,7 @@ describe Foreman::Export::Upstart, :fakefs do
       expect(File.read("/tmp/init/app-alpha.conf")).to      eq(example_export_file("upstart/app-alpha.conf"))
       expect(File.read("/tmp/init/app-alpha-1.conf")).to    eq(example_export_file("upstart/app-alpha-1.conf"))
       expect(File.read("/tmp/init/app-alpha-2.conf")).to    eq(example_export_file("upstart/app-alpha-2.conf"))
-      expect(File.exists?("/tmp/init/app-bravo-1.conf")).to eq(false)
+      expect(File.exist?("/tmp/init/app-bravo-1.conf")).to eq(false)
     end
   end
 

--- a/tasks/dist.rake
+++ b/tasks/dist.rake
@@ -40,7 +40,7 @@ def beta?
 end
 
 def clean(file)
-  rm file if File.exists?(file)
+  rm file if File.exist?(file)
 end
 
 def distribution_files(type=nil)


### PR DESCRIPTION
The singular methods were deprecated long ago and finally removed in Ruby 3.2.0.

See https://github.com/ruby/ruby/commit/bf97415c02b11a8949f715431aca9eeb6311add2