### PR TITLE
Fix misleading comment at the top of procfile.rb that indicates that hyphens "-" are not allowed in process names.

### DIFF
--- a/lib/foreman/procfile.rb
+++ b/lib/foreman/procfile.rb
@@ -4,7 +4,7 @@ require "foreman"
 #
 # A valid Procfile entry is captured by this regex:
 #
-#   /^([A-Za-z0-9_]+):\s*(.+)$/
+#   /^([A-Za-z0-9_-]+):\s*(.+)$/
 #
 # All other lines are ignored.
 #


### PR DESCRIPTION
Several of the ports listed in the README have incorrectly not allowed hyphens to be present in process names.  I believe it's because they took inspiration from [this misleading comment](https://github.com/ddollar/foreman/blob/a5f9b78fa5cf657733c8a4cfd01b2c0c151b4fce/lib/foreman/procfile.rb#L7) at the top of the procfile.rb file.

[Haskell](https://github.com/fujimura/houseman/blob/f4a5da44a35a04c84694118c91894bda41efaaa0/src/Procfile/Parse.hs#L21) 

[Go](https://github.com/mattn/goreman/blob/ebb9736b7c7f7f3425280ab69e1f7989fb34eadc/main.go#L103)

[Java](https://github.com/owenthereal/gaffer/blob/5704f4de1d438cc6527f7f4b5a439940607ccd54/src/main/java/gaffer/procfile/Procfile.java#L14)


[The actual regex used](https://github.com/ddollar/foreman/blob/a5f9b78fa5cf657733c8a4cfd01b2c0c151b4fce/lib/foreman/procfile.rb#L88) does permit hyphens in process names.