### PR TITLE
Fix insufficient Windows detection

### DIFF
--- a/lib/foreman.rb
+++ b/lib/foreman.rb
@@ -11,7 +11,7 @@ module Foreman
   end
 
   def self.windows?
-    defined?(RUBY_PLATFORM) and RUBY_PLATFORM =~ /(win|w)32$/
+    Gem.win_platform?
   end
 
 end


### PR DESCRIPTION
This restores proper Windows detection for MSYS-based Ruby versions (e.g. Ruby 2.4+ with RubyInstaller2)

Fixes https://github.com/ddollar/foreman/issues/789, https://github.com/ddollar/foreman/issues/797, https://github.com/ddollar/foreman/issues/793

Instead of just adding more patterns, I decided to use `Gem.win_platform?`. It checks a comprehensive list of patterns specific to Windows. It is available since around 2007, the oldest Ruby officially supported by Foreman (i.e. 2.3) was released in 2015.