### PR TITLE
Preserve stdin backward compatibility

### DIFF
--- a/lib/foreman/engine.rb
+++ b/lib/foreman/engine.rb
@@ -365,9 +365,10 @@ private
     @processes.each do |process|
       1.upto(formation[@names[process]]) do |n|
         reader, writer = process.interactive? ? PTY.open : create_pipe
+        use_stdin = process.interactive? || !@options[:interactive]
         begin
           pid = process.run(
-            input: process.interactive? ? $stdin : :close,
+            input: use_stdin ? $stdin : :close,
             output: writer,
             env: {
               'PORT' => port_for(process, n).to_s,


### PR DESCRIPTION
Do you plan on keeping backward compatibility for feature https://github.com/ddollar/foreman/pull/803?

If you don't then please close this PR. This means that after upgrading Foreman, `foreman start` will not boot for users whose Procfile contains `tailwindcss --watch` or `esbuild --watch` or any other process that needs an open stdin. They will have to switch to `tailwindcss --watch=always`, `esbuild --watch=forever`, or whatever hack they can find (if any) to make their setup work again.

If you plan on keeping backward compatibility, then this PR only closes stdin if the `--interactive` option is supplied. Otherwise it keeps the original behavior of keeping stdin open.