### PR TITLE
 Add option to suppress process name prefix 

### DIFF
--- a/lib/foreman/cli.rb
+++ b/lib/foreman/cli.rb
@@ -25,6 +25,7 @@ class Foreman::CLI < Foreman::Thor
   method_option :port,      :type => :numeric, :aliases => "-p"
   method_option :timeout,   :type => :numeric, :aliases => "-t", :desc => "Specify the amount of time (in seconds) processes have to shutdown gracefully before receiving a SIGKILL, defaults to 5."
   method_option :timestamp, :type => :boolean, :default => true, :desc => "Include timestamp in output"
+  method_option :prefix,    :type => :boolean, :default => true, :desc => "Include process name prefix in output"
 
   class << self
     # Hackery. Take the run method away from Thor so that we can redefine it.

--- a/lib/foreman/engine/cli.rb
+++ b/lib/foreman/engine/cli.rb
@@ -58,7 +58,7 @@ class Foreman::Engine::CLI < Foreman::Engine
       output  = ""
       output += $stdout.color(@colors[name.split(".").first].to_sym)
       output += "#{Time.now.strftime("%H:%M:%S")} " if options[:timestamp]
-      output += "#{pad_process_name(name)} | "
+      output += "#{pad_process_name(name)} | " if options[:prefix]
       output += $stdout.color(:reset)
       output += message
       $stdout.puts output


### PR DESCRIPTION
Referring to https://github.com/ddollar/foreman/issues/808 I hope this allows us to suppress all logging so that when used with Rails as the official multiple process monitor for dockerfile-rails gem, we can just send raw logs to stdout and let the target system ingest them without having to filter out the prefix.

This PR adds an option, --no-prefix, to suppress the process name prefix from foreman log lines.
