### PR TITLE
Add `Socketfile` support for systemd-style socket activation

### DIFF
--- a/lib/foreman/cli.rb
+++ b/lib/foreman/cli.rb
@@ -14,8 +14,9 @@ class Foreman::CLI < Thor
 
   map ["-v", "--version"] => :version
 
-  class_option :procfile, :type => :string, :aliases => "-f", :desc => "Default: Procfile"
-  class_option :root,     :type => :string, :aliases => "-d", :desc => "Default: Procfile directory"
+  class_option :procfile,    :type => :string, :aliases => "-f", :desc => "Default: Procfile"
+  class_option :socketfile, :type => :string, :aliases => "-s", :desc => "Default: Socketfile"
+  class_option :root,       :type => :string, :aliases => "-d", :desc => "Default: Procfile directory"
 
   desc "start [PROCESS]", "Start the application (or a specific PROCESS)"
 
@@ -42,6 +43,8 @@ class Foreman::CLI < Thor
     check_procfile!
     load_environment!
     engine.load_procfile(procfile)
+    engine.load_socketfile(socketfile)
+    engine.bind_sockets
     engine.options[:formation] = "#{process}=1" if process
     engine.start
   rescue Foreman::Procfile::EmptyFileError
@@ -166,6 +169,14 @@ private ######################################################################
       when options[:procfile] then options[:procfile]
       when options[:root]     then File.expand_path(File.join(options[:root], "Procfile"))
       else "Procfile"
+    end
+  end
+
+  def socketfile
+    case
+      when options[:socketfile] then options[:socketfile]
+      when options[:root]       then File.expand_path(File.join(options[:root], "Socketfile"))
+      else "Socketfile"
     end
   end
 end

--- a/lib/foreman/engine.rb
+++ b/lib/foreman/engine.rb
@@ -206,17 +206,12 @@ class Foreman::Engine
       next if specs.empty?
 
       @bound_sockets[name] = specs.map do |spec|
-        sock = Socket.new(:INET6, :STREAM)
-        sock.setsockopt(:SOCKET, :REUSEADDR, true)
-        sock.setsockopt(:IPV6, :V6ONLY, false)
-        addr = Socket.pack_sockaddr_in(spec[:port], spec[:host])
-        sock.bind(addr)
-        sock.listen(128)
+        sock = bind_one_socket(spec)
         # Clear O_NONBLOCK to match the systemd socket activation
         # protocol, which passes blocking sockets.
         flags = sock.fcntl(Fcntl::F_GETFL, 0)
         sock.fcntl(Fcntl::F_SETFL, flags & ~Fcntl::O_NONBLOCK)
-        { name: spec[:name], socket: sock }
+        { name: spec[:name], socket: sock, path: spec[:path] }
       end
     end
   end
@@ -329,6 +324,30 @@ class Foreman::Engine
   end
 
 private
+
+  def bind_one_socket(spec)
+    case spec[:type]
+    when :tcp
+      sock = Socket.new(:INET6, :STREAM)
+      sock.setsockopt(:SOCKET, :REUSEADDR, true)
+      sock.setsockopt(:IPV6, :V6ONLY, false)
+      addr = Socket.pack_sockaddr_in(spec[:port], spec[:host])
+      sock.bind(addr)
+      sock.listen(128)
+      sock
+    when :unix
+      path = spec[:path]
+      File.delete(path) if File.exist?(path)
+      sock = Socket.new(:UNIX, :STREAM)
+      sock.bind(Socket.pack_sockaddr_un(path))
+      sock.listen(128)
+      # 0660: group-rw, no world access
+      File.chmod(0660, path)
+      sock
+    else
+      raise "unknown socket type: #{spec[:type]}"
+    end
+  end
 
 ### Engine API ######################################################
 
@@ -543,5 +562,16 @@ private
     # Ok, we have no other option than to kill all of our children
     system  "sending SIGKILL to all processes"
     kill_children "SIGKILL"
+  ensure
+    cleanup_unix_sockets
+  end
+
+  def cleanup_unix_sockets
+    @bound_sockets.each_value do |sockets|
+      sockets.each do |s|
+        path = s[:path]
+        File.delete(path) if path && File.exist?(path)
+      end
+    end
   end
 end

--- a/lib/foreman/engine.rb
+++ b/lib/foreman/engine.rb
@@ -2,6 +2,9 @@ require "foreman"
 require "foreman/env"
 require "foreman/process"
 require "foreman/procfile"
+require "foreman/socketfile"
+require "socket"
+require "fcntl"
 require "tempfile"
 require "fileutils"
 require "thread"
@@ -37,6 +40,8 @@ class Foreman::Engine
     @running   = {}
     @readers   = {}
     @shutdown  = false
+    @socketfile = nil
+    @bound_sockets = {}  # process_name => [{ name:, socket: }]
 
     # Self-pipe for deferred signal-handling (ala djb: http://cr.yp.to/docs/selfpipe.html)
     reader, writer       = create_pipe
@@ -179,6 +184,40 @@ class Foreman::Engine
   def load_env(filename)
     Foreman::Env.new(filename).entries do |name, value|
       @env[name] = value
+    end
+  end
+
+  # Load a Socketfile and bind all declared sockets
+  #
+  # @param [String] filename  A Socketfile to load
+  #
+  def load_socketfile(filename)
+    @socketfile = Foreman::Socketfile.new(filename)
+  end
+
+  # Bind all sockets declared in the Socketfile.
+  # Must be called after load_procfile so process names are known.
+  #
+  def bind_sockets
+    return unless @socketfile&.any?
+
+    @names.each_value do |name|
+      specs = @socketfile.sockets_for(name)
+      next if specs.empty?
+
+      @bound_sockets[name] = specs.map do |spec|
+        sock = Socket.new(:INET6, :STREAM)
+        sock.setsockopt(:SOCKET, :REUSEADDR, true)
+        sock.setsockopt(:IPV6, :V6ONLY, false)
+        addr = Socket.pack_sockaddr_in(spec[:port], spec[:host])
+        sock.bind(addr)
+        sock.listen(128)
+        # Clear O_NONBLOCK to match the systemd socket activation
+        # protocol, which passes blocking sockets.
+        flags = sock.fcntl(Fcntl::F_GETFL, 0)
+        sock.fcntl(Fcntl::F_SETFL, flags & ~Fcntl::O_NONBLOCK)
+        { name: spec[:name], socket: sock }
+      end
     end
   end
 
@@ -364,10 +403,24 @@ private
       1.upto(formation[@names[process]]) do |n|
         reader, writer = create_pipe
         begin
-          pid = process.run(:output => writer, :env => {
-            "PORT" => port_for(process, n).to_s,
-            "PS" => name_for_index(process, n)
-          })
+          spawn_opts = {
+            :output => writer,
+            :env => {
+              "PORT" => port_for(process, n).to_s,
+              "PS" => name_for_index(process, n)
+            }
+          }
+
+          # Pass bound sockets via LISTEN_FDS protocol
+          name = @names[process]
+          if (sockets = @bound_sockets[name]) && !sockets.empty?
+            spawn_opts[:env]["LISTEN_FDS"] = sockets.length.to_s
+            fd_names = sockets.map { |s| s[:name] || "" }.join(":")
+            spawn_opts[:env]["LISTEN_FDNAMES"] = fd_names unless fd_names.empty?
+            spawn_opts[:sockets] = sockets.map { |s| s[:socket] }
+          end
+
+          pid = process.run(spawn_opts)
           writer.puts "started with pid #{pid}"
         rescue Errno::ENOENT
           writer.puts "unknown command: #{process.command}"

--- a/lib/foreman/process.rb
+++ b/lib/foreman/process.rb
@@ -49,9 +49,18 @@ class Foreman::Process
     env    = @options[:env].merge(options[:env] || {})
     output = options[:output] || $stdout
     runner = "#{Foreman.runner}".shellescape
-    
+
+    spawn_options = { :out => output, :err => output }
+
+    # Map passed sockets to fd 3, 4, 5, ... for LISTEN_FDS protocol
+    if (sockets = options[:sockets])
+      sockets.each_with_index do |sock, i|
+        spawn_options[3 + i] = sock
+      end
+    end
+
     Dir.chdir(cwd) do
-      Process.spawn env, expanded_command(env), :out => output, :err => output
+      Process.spawn env, expanded_command(env), spawn_options
     end
   end
 

--- a/lib/foreman/socketfile.rb
+++ b/lib/foreman/socketfile.rb
@@ -1,0 +1,80 @@
+require "socket"
+
+class Foreman::Socketfile
+
+  # Parse a Socketfile.
+  #
+  # Format:
+  #   process-name: name=host:port [name=host:port ...]
+  #
+  # Example:
+  #   hydra-server: http=:3000
+  #   hydra-queue-runner: rest=:8080 grpc=:50051
+  #
+  def initialize(filename)
+    @entries = {}
+    return unless filename && File.exist?(filename)
+
+    File.read(filename).lines.each do |line|
+      line = line.strip
+      next if line.empty? || line.start_with?("#")
+
+      process_name, sockets_str = line.split(":", 2)
+      next unless sockets_str
+
+      process_name = process_name.strip
+      @entries[process_name] = parse_sockets(sockets_str.strip)
+    end
+  end
+
+  # Get socket declarations for a process.
+  #
+  # @param [String] name  The process name
+  # @return [Array<Hash>]  Array of { name:, host:, port: } hashes, or empty array
+  #
+  def sockets_for(name)
+    @entries[name] || []
+  end
+
+  # Whether any sockets are declared.
+  #
+  def any?
+    !@entries.empty?
+  end
+
+  private
+
+  def parse_sockets(str)
+    str.split(/\s+/).map do |spec|
+      name, addr = spec.split("=", 2)
+      unless addr
+        addr = name
+        name = nil
+      end
+
+      host, port = parse_addr(addr)
+      { name: name, host: host, port: port.to_i }
+    end
+  end
+
+  def parse_addr(addr)
+    if addr.start_with?("[")
+      # IPv6: [::1]:port or [::]:port
+      bracket_end = addr.index("]")
+      host = addr[1...bracket_end]
+      port = addr[(bracket_end + 2)..]
+      [host, port]
+    elsif addr.start_with?(":")
+      # :port (all interfaces)
+      ["::", addr[1..]]
+    elsif addr.include?(":")
+      # host:port
+      parts = addr.rpartition(":")
+      [parts[0], parts[2]]
+    else
+      # just a port
+      ["::", addr]
+    end
+  end
+
+end

--- a/lib/foreman/socketfile.rb
+++ b/lib/foreman/socketfile.rb
@@ -5,11 +5,13 @@ class Foreman::Socketfile
   # Parse a Socketfile.
   #
   # Format:
-  #   process-name: name=host:port [name=host:port ...]
+  #   process-name: name=tcp://host:port [name=tcp://host:port ...]
+  #   process-name: name=unix:///path/to/socket
   #
   # Example:
-  #   hydra-server: http=:3000
-  #   hydra-queue-runner: rest=:8080 grpc=:50051
+  #   hydra-server: http=tcp://:3000
+  #   hydra-queue-runner: rest=tcp://:8080 grpc=tcp://:50051
+  #   hydra-drv-daemon: daemon=unix:///tmp/drv-daemon.sock
   #
   def initialize(filename)
     @entries = {}
@@ -30,7 +32,9 @@ class Foreman::Socketfile
   # Get socket declarations for a process.
   #
   # @param [String] name  The process name
-  # @return [Array<Hash>]  Array of { name:, host:, port: } hashes, or empty array
+  # @return [Array<Hash>]  Array of { name:, type:, ... } hashes, or empty array.
+  #   TCP:  { name:, type: :tcp, host:, port: }
+  #   Unix: { name:, type: :unix, path: }
   #
   def sockets_for(name)
     @entries[name] || []
@@ -52,12 +56,22 @@ class Foreman::Socketfile
         name = nil
       end
 
-      host, port = parse_addr(addr)
-      { name: name, host: host, port: port.to_i }
+      scheme, rest = addr.split("://", 2)
+      raise "missing scheme in #{spec.inspect}; use tcp:// or unix://" unless rest
+
+      case scheme
+      when "tcp"
+        host, port = parse_tcp_addr(rest)
+        { name: name, type: :tcp, host: host, port: port.to_i }
+      when "unix"
+        { name: name, type: :unix, path: rest }
+      else
+        raise "unknown socket scheme #{scheme.inspect} in #{spec.inspect}; use tcp:// or unix://"
+      end
     end
   end
 
-  def parse_addr(addr)
+  def parse_tcp_addr(addr)
     if addr.start_with?("[")
       # IPv6: [::1]:port or [::]:port
       bracket_end = addr.index("]")


### PR DESCRIPTION
> [!Note]
>
> I don't know if this project would accept a such a blatantly new feature extending the Procfile defacto spec, but it was useful for me, so I am making this PR. Look at https://github.com/mitsuhiko/systemfd for some prior art.

Foreman can now pre-bind sockets and pass them to child processes using the `LISTEN_FDS` / `LISTEN_FDNAMES` protocol (the same protocol systemd uses for socket activation). This lets processes survive restarts without rebinding their listen addresses.

A `Socketfile` declares which process gets which sockets:

    web: http=:3000
    api: grpc=:50051

Foreman binds these before spawning children, then maps them to fd 3, 4, ... via `Process.spawn` and sets the corresponding environment variables.